### PR TITLE
test: pin DAG-construction edge cases (gap #15)

### DIFF
--- a/tests/core/Flowthru.Core.Tests/Flow/CircularDependencyTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Flow/CircularDependencyTests.cs
@@ -1,0 +1,111 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Flow;
+using Flowthru.Prelude;
+
+namespace Flowthru.Core.Tests.Flow;
+
+/// <summary>
+/// DAG-construction invariants for the cycle-detection surface, ported
+/// from the legacy <c>02_Validation/GraphConstruction/CircularDependencyTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>StubFlowEndToEndTests.DependencyAnalyzerRejectsCycle</c> covers the
+/// happy-path two-step rejection; <c>PreFlightEdgeCaseTests.TwoStepCycle_…</c>
+/// and <c>ThreeStepCycle_…</c> assert message shape. These granular tests
+/// pin the remaining cases that the gap analysis flagged as missing:
+/// </para>
+/// <list type="bullet">
+///   <item>Self-loops (a step whose only input equals its only output)
+///     are intentionally allowed by the analyser — see
+///     <see cref="Flowthru.Flow.DependencyAnalyzer.Analyse"/>'s
+///     <c>producerIndex != i</c> guard. This pins that as a contract,
+///     not an accident.</item>
+///   <item>Two-step vs three-step cycles are reported as distinct
+///     <c>CycleDetected</c> results with the right step set in the cycle
+///     walk.</item>
+///   <item>A linear chain of the same arity (no cycle) builds cleanly,
+///     to keep the cycle assertions honest.</item>
+/// </list>
+/// </remarks>
+[TestFixture]
+public class CircularDependencyTests
+{
+  [Test]
+  public void Build_WhenSelfLoop_IsAllowed()
+  {
+    // The producer-index guard in DependencyAnalyzer.Analyse skips the
+    // self-edge before cycle detection runs, modelling "update-in-place"
+    // steps where the output replaces the input.
+    var item = ItemFactory.Singleton.Memory<int>("self-loop-item");
+
+    Assert.DoesNotThrow(() =>
+      FlowBuilder.CreateFlow("self-loop", builder =>
+      {
+        builder.AddStep<int, int>("update-in-place", x => x + 1, item, item);
+      })
+    );
+  }
+
+  [Test]
+  public void Build_WhenTwoStepCycle_ThrowsFlowBuildException()
+  {
+    var a = ItemFactory.Singleton.Memory<int>("two-cycle-a");
+    var b = ItemFactory.Singleton.Memory<int>("two-cycle-b");
+
+    var ex = Assert.Throws<FlowBuildException>(() =>
+      FlowBuilder.CreateFlow("two-cycle", builder =>
+      {
+        builder.AddStep<int, int>("a-to-b", x => x, a, b);
+        builder.AddStep<int, int>("b-to-a", x => x, b, a);
+      })
+    );
+    Assert.That(ex!.Message, Does.Contain("Cycle detected"));
+    Assert.That(ex.Message, Does.Contain("a-to-b"));
+    Assert.That(ex.Message, Does.Contain("b-to-a"));
+  }
+
+  [Test]
+  public void Build_WhenThreeStepCycle_ThrowsFlowBuildException()
+  {
+    // Distinct from the two-step case: the cycle walk must traverse
+    // three nodes and surface all three labels.
+    var a = ItemFactory.Singleton.Memory<int>("three-cycle-a");
+    var b = ItemFactory.Singleton.Memory<int>("three-cycle-b");
+    var c = ItemFactory.Singleton.Memory<int>("three-cycle-c");
+
+    var ex = Assert.Throws<FlowBuildException>(() =>
+      FlowBuilder.CreateFlow("three-cycle", builder =>
+      {
+        builder.AddStep<int, int>("step-a", x => x, a, b);
+        builder.AddStep<int, int>("step-b", x => x, b, c);
+        builder.AddStep<int, int>("step-c", x => x, c, a);
+      })
+    );
+    Assert.That(ex!.Message, Does.Contain("Cycle detected"));
+    Assert.That(ex.Message, Does.Contain("step-a"));
+    Assert.That(ex.Message, Does.Contain("step-b"));
+    Assert.That(ex.Message, Does.Contain("step-c"));
+  }
+
+  [Test]
+  public void Build_WhenLinearChain_SucceedsWithoutError()
+  {
+    // Negative control: keeps the cycle assertions honest by proving
+    // detection is specific, not accidentally triggered by any 3-step flow.
+    var input = ItemFactory.Singleton.Memory<int>("linear-input");
+    var stepOne = ItemFactory.Singleton.Memory<int>("linear-step-one");
+    var stepTwo = ItemFactory.Singleton.Memory<int>("linear-step-two");
+    var output = ItemFactory.Singleton.Memory<int>("linear-output");
+
+    var flow = FlowBuilder.CreateFlow("linear", builder =>
+    {
+      builder.AddStep<int, int>("a", x => x + 1, input, stepOne);
+      builder.AddStep<int, int>("b", x => x + 1, stepOne, stepTwo);
+      builder.AddStep<int, int>("c", x => x + 1, stepTwo, output);
+    });
+
+    Assert.That(flow.Steps.Select(s => s.Label), Is.EqualTo(new[] { "a", "b", "c" }),
+      "Topological order should follow the data-flow direction.");
+  }
+}

--- a/tests/core/Flowthru.Core.Tests/Flow/MultipleWritersTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Flow/MultipleWritersTests.cs
@@ -1,0 +1,119 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Flow;
+using Flowthru.Prelude;
+
+namespace Flowthru.Core.Tests.Flow;
+
+/// <summary>
+/// DAG-construction invariants for the single-producer law (§2.4),
+/// ported from the legacy
+/// <c>02_Validation/GraphConstruction/MultipleWritersTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>StubFlowEndToEndTests.DependencyAnalyzerRejectsDuplicateProducer</c>
+/// covers the two-writer happy-path rejection;
+/// <c>PreFlightEdgeCaseTests.TwoStepsWritingSameOutput_…</c> asserts the
+/// message names both contenders. These granular tests pin the
+/// remaining cases the gap analysis flagged as missing:
+/// </para>
+/// <list type="bullet">
+///   <item>Three-writer conflicts surface the same
+///     <see cref="DependencyAnalyzer.Result.DuplicateProducer"/> failure
+///     as the two-writer case, and the error names the contested item.</item>
+///   <item>A clean pipeline where every step writes a distinct item
+///     builds successfully — keeps the conflict assertions honest.</item>
+///   <item>A linear chain that consumes its predecessor's output (read-
+///     and-write of the <em>same</em> item by different steps in a
+///     chain) is not a conflict — only two <em>writers</em> trigger
+///     the rule.</item>
+/// </list>
+/// </remarks>
+[TestFixture]
+public class MultipleWritersTests
+{
+  [Test]
+  public void Build_WhenTwoStepsWriteSameOutput_ThrowsWithItemAndStepLabels()
+  {
+    var input = ItemFactory.Singleton.Memory<int>("two-writers-input");
+    var shared = ItemFactory.Singleton.Memory<int>("two-writers-shared");
+
+    var ex = Assert.Throws<FlowBuildException>(() =>
+      FlowBuilder.CreateFlow("two-writers", builder =>
+      {
+        builder.AddStep<int, int>("first", x => x + 1, input, shared);
+        builder.AddStep<int, int>("second", x => x + 2, input, shared);
+      })
+    );
+    Assert.That(ex!.Message, Does.Contain("two-writers-shared"),
+      "Duplicate-producer message should name the contested item.");
+    Assert.That(ex.Message, Does.Contain("first"));
+    Assert.That(ex.Message, Does.Contain("second"));
+  }
+
+  [Test]
+  public void Build_WhenThreeStepsWriteSameOutput_ThrowsWithAllStepLabels()
+  {
+    // The duplicate-accumulator in DependencyAnalyzer.Analyse must
+    // collect every offender, not just the first pair.
+    var inputA = ItemFactory.Singleton.Memory<int>("three-writers-input-a");
+    var inputB = ItemFactory.Singleton.Memory<int>("three-writers-input-b");
+    var inputC = ItemFactory.Singleton.Memory<int>("three-writers-input-c");
+    var shared = ItemFactory.Singleton.Memory<int>("three-writers-shared");
+
+    var ex = Assert.Throws<FlowBuildException>(() =>
+      FlowBuilder.CreateFlow("three-writers", builder =>
+      {
+        builder.AddStep<int, int>("alpha", x => x + 1, inputA, shared);
+        builder.AddStep<int, int>("beta", x => x + 2, inputB, shared);
+        builder.AddStep<int, int>("gamma", x => x + 3, inputC, shared);
+      })
+    );
+    Assert.That(ex!.Message, Does.Contain("three-writers-shared"));
+    Assert.That(ex.Message, Does.Contain("alpha"));
+    Assert.That(ex.Message, Does.Contain("beta"));
+    Assert.That(ex.Message, Does.Contain("gamma"),
+      "Every offending step must be reported, not just the first pair."
+    );
+  }
+
+  [Test]
+  public void Build_WhenEachStepWritesDistinctOutput_SucceedsWithoutError()
+  {
+    // Negative control: ensures the rule is specific to shared outputs,
+    // not any shared input.
+    var input = ItemFactory.Singleton.Memory<int>("distinct-input");
+    var outA = ItemFactory.Singleton.Memory<int>("distinct-out-a");
+    var outB = ItemFactory.Singleton.Memory<int>("distinct-out-b");
+    var outC = ItemFactory.Singleton.Memory<int>("distinct-out-c");
+
+    var flow = FlowBuilder.CreateFlow("distinct-writers", builder =>
+    {
+      builder.AddStep<int, int>("a", x => x + 1, input, outA);
+      builder.AddStep<int, int>("b", x => x + 2, input, outB);
+      builder.AddStep<int, int>("c", x => x + 3, input, outC);
+    });
+
+    Assert.That(flow.Steps, Has.Count.EqualTo(3));
+  }
+
+  [Test]
+  public void Build_WhenStepReadsWhatAnotherWrites_SucceedsWithoutError()
+  {
+    // The rule rejects multiple writers, not multiple readers — a
+    // linear chain that re-reads each predecessor's output is legal.
+    var input = ItemFactory.Singleton.Memory<int>("chain-input");
+    var stepOne = ItemFactory.Singleton.Memory<int>("chain-step-one");
+    var stepTwo = ItemFactory.Singleton.Memory<int>("chain-step-two");
+    var output = ItemFactory.Singleton.Memory<int>("chain-output");
+
+    var flow = FlowBuilder.CreateFlow("read-after-write", builder =>
+    {
+      builder.AddStep<int, int>("write-one", x => x + 1, input, stepOne);
+      builder.AddStep<int, int>("read-and-write-two", x => x + 1, stepOne, stepTwo);
+      builder.AddStep<int, int>("read-and-write-final", x => x + 1, stepTwo, output);
+    });
+
+    Assert.That(flow.Steps, Has.Count.EqualTo(3));
+  }
+}


### PR DESCRIPTION
## Summary

Ports the granular `CircularDependencyTests` + `MultipleWritersTests` cases from the quarantined `02_Validation/GraphConstruction/` dir into the layer-based `Flow/` test dir. Addresses gap #15 from `docs/scratch/test-coverage-gap-analysis.md`.

Existing coverage in `StubFlowEndToEndTests` + `PreFlightEdgeCaseTests` is broad (1 test each for cycle + duplicate-producer rejection). These tests pin the specific contracts the gap analysis flagged as missing:

- **Self-loops are allowed** — the producer-index guard in `DependencyAnalyzer.Analyse` skips the self-edge before cycle detection runs, modelling update-in-place steps.
- **Two-step vs three-step cycles** surface distinct cycle walks; all step labels appear in the cycle description.
- **Three-writer conflicts** collect every offender in the error message, not just the first pair.
- **Linear chains** that re-read predecessor outputs are not conflicts — only multiple *writers*, not multiple *readers*, trigger the rule.

8 new tests across two files. No src changes.

## Test plan

- [x] `dotnet build tests/core/Flowthru.Core.Tests` — succeeds (warnings only, pre-existing).
- [x] `dotnet test tests/core/Flowthru.Core.Tests --filter "FullyQualifiedName~CircularDependency|FullyQualifiedName~MultipleWriters"` — 9/9 passed (8 new + 1 unrelated match).
- [x] Full suite `dotnet test tests/core/Flowthru.Core.Tests` — 261/261 passed.

Generated with [Claude Code](https://claude.com/claude-code)