### PR TITLE
feat(flow): add explicit zero-arity AddStep API surface (gap #17)

### DIFF
--- a/src/core/Flowthru.Core.SourceGenerators/FlowBuilderGenerator.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/FlowBuilderGenerator.cs
@@ -69,18 +69,38 @@ public class FlowBuilderGenerator : IIncrementalGenerator
       """
     );
 
-    // Generate overloads across the full matrix. No skip rule — the generator owns
-    // every shape, including 0×0 and 1×1.
-    for (int inputs = 0; inputs <= MaxInputs; inputs++)
+    // Two API surfaces share the same overload body:
+    //   plural: false → conventional `input:` / `output:` (singular) params,
+    //                   empty side omitted. Full 0-8 × 0-8 matrix.
+    //   plural: true  → explicit `inputs:` / `outputs:` (plural) params, empty
+    //                   side typed as ValueTuple (caller passes
+    //                   `default(ValueTuple)` as a deliberate signal). Emitted
+    //                   only when at least one side is empty — when both sides
+    //                   are populated the plural form would collide with the
+    //                   singular signature.
+    var variants = new[]
     {
-      for (int outputs = 0; outputs <= MaxOutputs; outputs++)
+      TransformVariant.Sync,
+      TransformVariant.Async,
+      TransformVariant.AsyncWithCancellation,
+    };
+    foreach (var plural in new[] { false, true })
+    {
+      for (int inputs = 0; inputs <= MaxInputs; inputs++)
       {
-        GenerateAddStepOverload(sb, inputs, outputs, TransformVariant.Sync);
-        sb.AppendLine();
-        GenerateAddStepOverload(sb, inputs, outputs, TransformVariant.Async);
-        sb.AppendLine();
-        GenerateAddStepOverload(sb, inputs, outputs, TransformVariant.AsyncWithCancellation);
-        sb.AppendLine();
+        for (int outputs = 0; outputs <= MaxOutputs; outputs++)
+        {
+          if (plural && inputs > 0 && outputs > 0)
+          {
+            continue;
+          }
+
+          foreach (var variant in variants)
+          {
+            GenerateAddStepOverload(sb, inputs, outputs, variant, plural);
+            sb.AppendLine();
+          }
+        }
       }
     }
 
@@ -89,45 +109,68 @@ public class FlowBuilderGenerator : IIncrementalGenerator
     context.AddSource("FlowBuilder.Generated.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
   }
 
+  /// <summary>
+  /// Emits one AddStep overload. The <paramref name="plural"/> flag selects
+  /// between two API surfaces that share the same body:
+  /// <list type="bullet">
+  /// <item><description>
+  ///   <c>plural: false</c> — conventional <c>input:</c> / <c>output:</c>
+  ///   singular parameters. Empty sides are omitted entirely.
+  /// </description></item>
+  /// <item><description>
+  ///   <c>plural: true</c> — explicit <c>inputs:</c> / <c>outputs:</c> plural
+  ///   parameters. Empty sides are typed as <see cref="System.ValueTuple"/>
+  ///   so the caller passes <c>default(ValueTuple)</c> as a deliberate signal.
+  /// </description></item>
+  /// </list>
+  /// </summary>
   private static void GenerateAddStepOverload(
     StringBuilder sb,
     int inputCount,
     int outputCount,
-    TransformVariant variant
+    TransformVariant variant,
+    bool plural = false
   )
   {
-    GenerateXmlDoc(sb, inputCount, outputCount, variant);
+    GenerateXmlDoc(sb, inputCount, outputCount, variant, plural);
 
     var typeParams = GenerateTypeParameters(inputCount, outputCount);
     var typeParamSection = string.IsNullOrEmpty(typeParams) ? "" : $"<{typeParams}>";
     var funcSignature = GenerateFuncSignature(inputCount, outputCount, variant);
+    var inputParamName = plural ? "inputs" : "input";
+    var outputParamName = plural ? "outputs" : "output";
 
     sb.AppendLine($"  public FlowBuilder AddStep{typeParamSection}(");
     sb.AppendLine("    string label,");
     sb.AppendLine($"    {funcSignature} transform,");
+
+    // Singular form omits the empty side entirely; plural form types it as ValueTuple.
     if (inputCount > 0)
     {
-      sb.AppendLine($"    {GenerateInputParameter(inputCount)} input,");
+      sb.AppendLine($"    {GenerateInputParameter(inputCount)} {inputParamName},");
+    }
+    else if (plural)
+    {
+      sb.AppendLine($"    ValueTuple {inputParamName},");
     }
     if (outputCount > 0)
     {
-      sb.AppendLine($"    {GenerateOutputParameter(outputCount)} output,");
+      sb.AppendLine($"    {GenerateOutputParameter(outputCount)} {outputParamName},");
     }
+    else if (plural)
+    {
+      sb.AppendLine($"    ValueTuple {outputParamName},");
+    }
+
     sb.AppendLine("    string description = \"\"");
     sb.AppendLine("  )");
     sb.AppendLine("  {");
 
-    GenerateInputDeconstruction(sb, inputCount);
-    GenerateOutputDeconstruction(sb, outputCount);
+    GenerateInputDeconstruction(sb, inputCount, inputParamName);
+    GenerateOutputDeconstruction(sb, outputCount, outputParamName);
 
-    var inputsArg =
-      inputCount == 0
-        ? "System.Array.Empty<INode>()"
-        : $"new List<INode> {{ {GenerateInputsList(inputCount)} }}";
-    var outputsArg =
-      outputCount == 0
-        ? "System.Array.Empty<INode>()"
-        : $"new List<INode> {{ {GenerateOutputsList(outputCount)} }}";
+    var inputsArg = BuildNodeListExpression(inputCount, inputParamName, isInput: true);
+    var outputsArg = BuildNodeListExpression(outputCount, outputParamName, isInput: false);
 
     sb.AppendLine(
       $$"""
@@ -147,11 +190,34 @@ public class FlowBuilderGenerator : IIncrementalGenerator
     );
   }
 
+  /// <summary>
+  /// Builds the C# expression used to populate the <c>FlowStep.inputs</c> or
+  /// <c>FlowStep.outputs</c> list for a given arity. Reads as one of:
+  /// <c>System.Array.Empty&lt;INode&gt;()</c> (arity 0),
+  /// <c>new List&lt;INode&gt; { paramName }</c> (arity 1), or
+  /// <c>new List&lt;INode&gt; { paramName1, paramName2, ... }</c> (arity ≥ 2,
+  /// where each <c>paramNameN</c> is a deconstructed local).
+  /// </summary>
+  private static string BuildNodeListExpression(int count, string paramName, bool isInput)
+  {
+    if (count == 0)
+    {
+      return "System.Array.Empty<INode>()";
+    }
+    if (count == 1)
+    {
+      return $"new List<INode> {{ {paramName} }}";
+    }
+    var items = isInput ? GenerateInputsList(count) : GenerateOutputsList(count);
+    return $"new List<INode> {{ {items} }}";
+  }
+
   private static void GenerateXmlDoc(
     StringBuilder sb,
     int inputCount,
     int outputCount,
-    TransformVariant variant
+    TransformVariant variant,
+    bool plural = false
   )
   {
     var variantDesc = variant switch
@@ -197,17 +263,34 @@ public class FlowBuilderGenerator : IIncrementalGenerator
 
     sb.AppendLine("  /// <param name=\"label\">Unique identifier for this step</param>");
     sb.AppendLine($"  /// <param name=\"transform\">{transformDesc}</param>");
-    if (inputCount > 0)
+
+    if (plural)
     {
       sb.AppendLine(
-        "  /// <param name=\"input\">Catalog item or tuple of catalog items providing input data</param>"
+        inputCount == 0
+          ? "  /// <param name=\"inputs\">Explicit empty tuple (<c>()</c>) — the step has no inputs.</param>"
+          : "  /// <param name=\"inputs\">Catalog item or tuple of catalog items providing input data.</param>"
+      );
+      sb.AppendLine(
+        outputCount == 0
+          ? "  /// <param name=\"outputs\">Explicit empty tuple (<c>()</c>) — the step has no outputs.</param>"
+          : "  /// <param name=\"outputs\">Catalog item or tuple of catalog items to store output data.</param>"
       );
     }
-    if (outputCount > 0)
+    else
     {
-      sb.AppendLine(
-        "  /// <param name=\"output\">Catalog item or tuple of catalog items to store output data</param>"
-      );
+      if (inputCount > 0)
+      {
+        sb.AppendLine(
+          "  /// <param name=\"input\">Catalog item or tuple of catalog items providing input data</param>"
+        );
+      }
+      if (outputCount > 0)
+      {
+        sb.AppendLine(
+          "  /// <param name=\"output\">Catalog item or tuple of catalog items to store output data</param>"
+        );
+      }
     }
     sb.AppendLine(
       "  /// <param name=\"description\">Optional description of the step's purpose</param>"
@@ -297,43 +380,46 @@ public class FlowBuilderGenerator : IIncrementalGenerator
     return $"({types})";
   }
 
-  private static void GenerateInputDeconstruction(StringBuilder sb, int inputCount)
+  private static void GenerateInputDeconstruction(
+    StringBuilder sb,
+    int inputCount,
+    string sourceName
+  ) => GenerateTupleDeconstruction(sb, inputCount, "input", sourceName);
+
+  private static void GenerateOutputDeconstruction(
+    StringBuilder sb,
+    int outputCount,
+    string sourceName
+  ) => GenerateTupleDeconstruction(sb, outputCount, "output", sourceName);
+
+  /// <summary>
+  /// Emits a deconstruction statement of the form
+  /// <c>var (slot1, slot2, ...) = source;</c> when <paramref name="count"/> ≥ 2.
+  /// For <paramref name="count"/> ≤ 1 the parameter is already a single value
+  /// (or absent) and no deconstruction is needed.
+  /// </summary>
+  private static void GenerateTupleDeconstruction(
+    StringBuilder sb,
+    int count,
+    string slotPrefix,
+    string sourceName
+  )
   {
-    if (inputCount <= 1)
+    if (count <= 1)
     {
       return;
     }
 
     sb.Append("    var (");
-    for (int i = 1; i <= inputCount; i++)
+    for (int i = 1; i <= count; i++)
     {
       if (i > 1)
       {
         sb.Append(", ");
       }
-      sb.Append($"input{i}");
+      sb.Append($"{slotPrefix}{i}");
     }
-    sb.AppendLine(") = input;");
-    sb.AppendLine();
-  }
-
-  private static void GenerateOutputDeconstruction(StringBuilder sb, int outputCount)
-  {
-    if (outputCount <= 1)
-    {
-      return;
-    }
-
-    sb.Append("    var (");
-    for (int i = 1; i <= outputCount; i++)
-    {
-      if (i > 1)
-      {
-        sb.Append(", ");
-      }
-      sb.Append($"output{i}");
-    }
-    sb.AppendLine(") = output;");
+    sb.AppendLine($") = {sourceName};");
     sb.AppendLine();
   }
 

--- a/src/core/Flowthru.Core/Flows/FlowBuilder.cs
+++ b/src/core/Flowthru.Core/Flows/FlowBuilder.cs
@@ -67,11 +67,36 @@ namespace Flowthru.Core.Flows;
 ///         input: catalog.Config,
 ///         output: catalog.ExternalData
 ///     );
+///
+///     // Zero-input source step (no upstream dependency) — use the explicit
+///     // plural `inputs:` form with `default(ValueTuple)` as the empty marker.
+///     builder.AddStep(
+///         label: "SeedData",
+///         transform: SeedDataStep.Create(),
+///         inputs: default(ValueTuple),
+///         outputs: (catalog.TrainSplit, catalog.TestSplit)
+///     );
+///
+///     // Zero-output sink step (no downstream dependency) — use the explicit
+///     // plural `outputs:` form with `default(ValueTuple)` as the empty marker.
+///     builder.AddStep(
+///         label: "PublishReport",
+///         transform: PublishReportStep.Create(),
+///         inputs: catalog.ModelInputTable,
+///         outputs: default(ValueTuple)
+///     );
 /// });
 ///
 /// flow.Build();
 /// await flow.ExecuteAsync();
 /// </code>
+/// <para>
+/// <strong>Zero-arity steps:</strong> Steps with no inputs, no outputs, or both
+/// are first-class shapes. Use the explicit plural <c>inputs:</c> / <c>outputs:</c>
+/// parameter form with <c>default(ValueTuple)</c> for the empty side to make the
+/// authoring intent explicit at the call site. (C# does not allow <c>()</c> as a
+/// literal expression — <c>default(ValueTuple)</c> is the canonical alternative.)
+/// </para>
 /// </remarks>
 public partial class FlowBuilder
 {

--- a/tests/core/Flowthru.Core.Tests/Flow/ZeroArityStepTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Flow/ZeroArityStepTests.cs
@@ -1,16 +1,20 @@
 using Flowthru.Core.Data;
 using Flowthru.Core.Flows;
 
-namespace Flowthru.Core.Tests.Execution;
+namespace Flowthru.Core.Tests.FlowAuthoring;
 
 /// <summary>
 /// Tests verifying execution of steps with zero inputs and/or zero outputs across
-/// all transform variants (sync, async, async-with-CancellationToken). These shapes
-/// replace the legacy <c>NoData</c>/<c>NullStorageAdapter</c> sentinel pattern.
+/// all transform variants (sync, async, async-with-CancellationToken).
+///
+/// All call-sites use the explicit plural <c>inputs:</c> / <c>outputs:</c> form,
+/// with <c>()</c> (empty <see cref="ValueTuple"/>) as the deliberate signal for
+/// a side of arity zero. This is the user-facing API contract for source-only
+/// (zero-input) and sink-only (zero-output) steps.
 /// </summary>
 [TestFixture]
-[Category("Execution")]
-[Category("StepExecution")]
+[Category("Flow")]
+[Category("ZeroArity")]
 public class ZeroArityStepTests
 {
   // ─────────────────────────────────────────────────────────────────────────
@@ -24,7 +28,12 @@ public class ZeroArityStepTests
 
     var pipeline = FlowBuilder.CreateFlow(builder =>
     {
-      builder.AddStep(label: "Tick", transform: () => counter.Increment());
+      builder.AddStep(
+        label: "Tick",
+        transform: () => counter.Increment(),
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple)
+      );
     });
 
     pipeline.Build();
@@ -46,7 +55,9 @@ public class ZeroArityStepTests
         {
           await Task.Yield();
           counter.Increment();
-        }
+        },
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple)
       );
     });
 
@@ -70,7 +81,9 @@ public class ZeroArityStepTests
         {
           captured = ct;
           await Task.Yield();
-        }
+        },
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple)
       );
     });
 
@@ -83,13 +96,15 @@ public class ZeroArityStepTests
   }
 
   [Test]
-  public async Task ZeroByZero_WithDescription_RecordsDescription()
+  public void ZeroByZero_WithDescription_RecordsDescription()
   {
     var pipeline = FlowBuilder.CreateFlow(builder =>
     {
       builder.AddStep(
         label: "TickWithDesc",
         transform: () => { },
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple),
         description: "Smoke-test step with no IO."
       );
     });
@@ -111,7 +126,12 @@ public class ZeroArityStepTests
 
     var pipeline = FlowBuilder.CreateFlow(builder =>
     {
-      builder.AddStep(label: "Produce", transform: () => 42, output: catalog.OutputInt);
+      builder.AddStep(
+        label: "Produce",
+        transform: () => 42,
+        inputs: default(ValueTuple),
+        outputs: catalog.OutputInt
+      );
     });
 
     pipeline.Build();
@@ -135,7 +155,8 @@ public class ZeroArityStepTests
           await Task.Yield();
           return 99;
         },
-        output: catalog.OutputInt
+        inputs: default(ValueTuple),
+        outputs: catalog.OutputInt
       );
     });
 
@@ -156,16 +177,23 @@ public class ZeroArityStepTests
       builder.AddStep(
         label: "ProduceTuple",
         transform: () => (1, "two", 3.0),
-        output: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble)
+        inputs: default(ValueTuple),
+        outputs: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble)
       );
     });
 
     pipeline.Build();
     await pipeline.RunAsync(CancellationToken.None);
 
-    Assert.That(await catalog.OutputInt.Load().Run(), Is.EqualTo(1));
-    Assert.That(await catalog.OutputString.Load().Run(), Is.EqualTo("two"));
-    Assert.That(await catalog.OutputDouble.Load().Run(), Is.EqualTo(3.0));
+    var intResult = await catalog.OutputInt.Load().Run();
+    var stringResult = await catalog.OutputString.Load().Run();
+    var doubleResult = await catalog.OutputDouble.Load().Run();
+    Assert.Multiple(() =>
+    {
+      Assert.That(intResult, Is.EqualTo(1));
+      Assert.That(stringResult, Is.EqualTo("two"));
+      Assert.That(doubleResult, Is.EqualTo(3.0));
+    });
   }
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -184,7 +212,8 @@ public class ZeroArityStepTests
       builder.AddStep(
         label: "Consume",
         transform: (int v) => captured = v,
-        input: catalog.OutputInt
+        inputs: catalog.OutputInt,
+        outputs: default(ValueTuple)
       );
     });
 
@@ -210,7 +239,8 @@ public class ZeroArityStepTests
           await Task.Yield();
           captured = v;
         },
-        input: catalog.OutputInt
+        inputs: catalog.OutputInt,
+        outputs: default(ValueTuple)
       );
     });
 
@@ -242,16 +272,20 @@ public class ZeroArityStepTests
           capturedString = tuple.s;
           capturedDouble = tuple.d;
         },
-        input: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble)
+        inputs: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble),
+        outputs: default(ValueTuple)
       );
     });
 
     pipeline.Build();
     await pipeline.RunAsync(CancellationToken.None);
 
-    Assert.That(capturedInt, Is.EqualTo(5));
-    Assert.That(capturedString, Is.EqualTo("hello"));
-    Assert.That(capturedDouble, Is.EqualTo(2.5));
+    Assert.Multiple(() =>
+    {
+      Assert.That(capturedInt, Is.EqualTo(5));
+      Assert.That(capturedString, Is.EqualTo("hello"));
+      Assert.That(capturedDouble, Is.EqualTo(2.5));
+    });
   }
 
   [Test]
@@ -273,7 +307,8 @@ public class ZeroArityStepTests
           await Task.Yield();
           sum = tuple.i + tuple.d;
         },
-        input: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble)
+        inputs: (catalog.OutputInt, catalog.OutputString, catalog.OutputDouble),
+        outputs: default(ValueTuple)
       );
     });
 
@@ -286,8 +321,6 @@ public class ZeroArityStepTests
   // ─────────────────────────────────────────────────────────────────────────
   // Multi-arity async-with-CancellationToken — exercises the engine's
   // dataParameterCount logic that strips trailing CT from multi-input invokes.
-  // Previously unreachable: pre-Phase-1, the generator emitted no CT variants
-  // for non-1×1 arities.
   // ─────────────────────────────────────────────────────────────────────────
 
   [Test]
@@ -366,7 +399,9 @@ public class ZeroArityStepTests
     {
       builder.AddStep(
         label: "RespectsToken",
-        transform: (CancellationToken ct) => Task.Delay(TimeSpan.FromMinutes(5), ct)
+        transform: (CancellationToken ct) => Task.Delay(TimeSpan.FromMinutes(5), ct),
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple)
       );
     });
 
@@ -389,7 +424,8 @@ public class ZeroArityStepTests
       builder.AddStep(
         label: "ConsumeWithToken",
         transform: (int value, CancellationToken ct) => Task.Delay(TimeSpan.FromMinutes(5), ct),
-        input: catalog.OutputInt
+        inputs: catalog.OutputInt,
+        outputs: default(ValueTuple)
       );
     });
 
@@ -425,7 +461,8 @@ public class ZeroArityStepTests
           capturedToken = ct;
           return 123;
         },
-        output: catalog.OutputInt
+        inputs: default(ValueTuple),
+        outputs: catalog.OutputInt
       );
     });
 
@@ -459,7 +496,8 @@ public class ZeroArityStepTests
           capturedValue = value;
           capturedToken = ct;
         },
-        input: catalog.OutputInt
+        inputs: catalog.OutputInt,
+        outputs: default(ValueTuple)
       );
     });
 
@@ -486,12 +524,17 @@ public class ZeroArityStepTests
     var pipeline = FlowBuilder.CreateFlow(builder =>
     {
       // 0×1 — produces seed value (no upstream dependency).
-      builder.AddStep(label: "Seed", transform: () => 10, output: catalog.OutputInt);
+      builder.AddStep(
+        label: "Seed",
+        transform: () => 10,
+        inputs: default(ValueTuple),
+        outputs: catalog.OutputInt
+      );
 
-      // 1×1 — conventional transform consuming the seed.
+      // 1×1 — conventional transform consuming the seed (singular API form).
       builder.AddStep(
         label: "Double",
-        transform: (int v) => v * 2,
+        transform: (int v) => (double)(v * 2),
         input: catalog.OutputInt,
         output: catalog.OutputDouble
       );
@@ -500,7 +543,8 @@ public class ZeroArityStepTests
       builder.AddStep(
         label: "Notify",
         transform: (double _) => sideEffectFired = true,
-        input: catalog.OutputDouble
+        inputs: catalog.OutputDouble,
+        outputs: default(ValueTuple)
       );
     });
 
@@ -528,7 +572,9 @@ public class ZeroArityStepTests
     {
       builder.AddStep(
         label: "Boom",
-        transform: () => throw new InvalidOperationException("boom from 0×0")
+        transform: () => throw new InvalidOperationException("boom from 0x0"),
+        inputs: default(ValueTuple),
+        outputs: default(ValueTuple)
       );
     });
 
@@ -539,7 +585,7 @@ public class ZeroArityStepTests
     {
       Assert.That(result.Success, Is.False);
       Assert.That(result.Exception, Is.Not.Null);
-      Assert.That(result.Exception!.Message, Does.Contain("boom from 0×0"));
+      Assert.That(result.Exception!.Message, Does.Contain("boom from 0x0"));
     });
   }
 
@@ -553,8 +599,9 @@ public class ZeroArityStepTests
       builder.AddStep(
         label: "ProduceBoom",
         transform: () =>
-          Task.FromException<int>(new InvalidOperationException("boom from 0×1")),
-        output: catalog.OutputInt
+          Task.FromException<int>(new InvalidOperationException("boom from 0x1")),
+        inputs: default(ValueTuple),
+        outputs: catalog.OutputInt
       );
     });
 
@@ -565,7 +612,7 @@ public class ZeroArityStepTests
     {
       Assert.That(result.Success, Is.False);
       Assert.That(result.Exception, Is.Not.Null);
-      Assert.That(result.Exception!.Message, Does.Contain("boom from 0×1"));
+      Assert.That(result.Exception!.Message, Does.Contain("boom from 0x1"));
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds plural-form `inputs:` / `outputs:` AddStep overloads to `FlowBuilder` for cases where at least one side is empty. Callers pass `default(ValueTuple)` on the empty side as a deliberate signal — the zero-arity case now looks like an authoring choice rather than a missing argument.
- Ports the 20-test zero-arity matrix from the quarantined `03_Execution/ZeroArityStepTests` into the active layer-based `Flow/ZeroArityStepTests`, rewritten to exercise the new explicit plural form across the sync / async / async-with-CT × 0×0, 0×N, N×0 shape matrix plus the mixed-with-conventional and transform-throws cases.
- Refactors the generator so the singular and plural emit paths share one `GenerateAddStepOverload(..., plural)` body, with shared `BuildNodeListExpression` and `GenerateTupleDeconstruction` helpers.

Closes gap #17 (Zero-arity steps) from `docs/scratch/test-coverage-gap-analysis.md`.

### API surface
```csharp
// zero inputs, two outputs
pipeline.AddStep(
  label: "SplitData",
  transform: SplitDataStep.Create(),
  inputs: default(ValueTuple),
  outputs: (catalog.TrainSplit, catalog.TestSplit)
);

// one input, zero outputs
pipeline.AddStep(
  label: "PublishReport",
  transform: PublishReportStep.Create(),
  inputs: catalog.ModelInputTable,
  outputs: default(ValueTuple)
);
```

Note: the task spec showed `inputs: ()` as the target syntax. C# does not allow `()` as an expression literal in any context I tested (latest / preview LangVersion, .NET 10). `default(ValueTuple)` is the canonical alternative and is now the documented form.

## Test plan
- [x] `dotnet build tests/core/Flowthru.Core.Tests` — green, no errors.
- [x] `dotnet test tests/core/Flowthru.Core.Tests --filter "FullyQualifiedName~ZeroArity"` — 20/20 passing.
- [x] `dotnet test tests/core/Flowthru.Core.Tests` — 476/476 passing.
- [x] `dotnet build` (full solution) — green.
- [x] Source-generator unit tests for `FlowBuilderGenerator` still pass (3 pre-existing failures in `StepMetadataGenerator` tests are unrelated — verified on baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)