### PR TITLE
feat: FlowSource for streaming-native architecture

### DIFF
--- a/Flowthru.slnx
+++ b/Flowthru.slnx
@@ -60,6 +60,7 @@
   <Project Path="examples/starter/SpaceflightsPython/SpaceflightsPython.csproj" />
   <Project Path="examples/advanced/FlowthruCoverage/FlowthruCoverage.csproj" />
   <Project Path="examples/advanced/RetailDataSplitFlow/RetailDataSplitFlow.csproj" />
+  <Project Path="examples/advanced/StreamingBulkLoad/StreamingBulkLoad.csproj" />
   <Project Path="examples/advanced/SpaceflightsDistributed/SpaceflightsDistributed.DataProcessing/SpaceflightsDistributed.DataProcessing.csproj" />
   <Project Path="examples/advanced/SpaceflightsDistributed/SpaceflightsDistributed.DataScience/SpaceflightsDistributed.DataScience.csproj" />
   <Project Path="examples/advanced/SpaceflightsDistributed/SpaceflightsDistributed.Reporting/SpaceflightsDistributed.Reporting.csproj" />

--- a/docs/explanation/advanced/core-architecture.md
+++ b/docs/explanation/advanced/core-architecture.md
@@ -35,7 +35,7 @@ The FP layer in [src/core/Flowthru.Core/Prelude/](/src/core/Flowthru.Core/Prelud
 
 The Prelude is derived from a small slice of [LanguageExt](https://github.com/louthy/language-ext), but the [Flowthru.Core README](/src/core/Flowthru.Core/README.md) is emphatic that this is **not a port**. We took only the FP primitives Flowthru actively uses, and we own them going forward. No HKTs (`K<F, A>`), no generic `Functor<F>` / `Applicative<F>` / `Monad<F>` typeclasses, no monad transformer stack, no `Either` / `Option` / `Try` / `Fin`, no `Seq` / `Lst` / `Iterable`. Every additional abstraction would buy generality we don't need at the cost of API surface a future contributor would have to learn.
 
-The four primitives that survived the cut are:
+The five primitives that survived the cut are:
 
 #### `FlowIO<A>` — [Prelude/FlowIO.cs](/src/core/Flowthru.Core/Prelude/FlowIO.cs)
 
@@ -59,6 +59,16 @@ Two consequences fall out for free:
 **Side effects can't be accidentally dropped.** A `FlowIO<A>` value held in a variable does nothing until `Run` is called. There is no `var = doThing()` shape that performs an I/O and forgets the result. The framework is the only thing that calls `Run`, at one specific point in the scheduler, and the result is structurally inspected, not thrown.
 
 **Errors can't be silently swallowed.** A failing `FlowIO<A>` is still a value; consumers must pattern-match `EffResult<A>` to get at the success. Forgetting to handle the failure is a compile-time error at every consumer site.
+
+#### `FlowSource<A>` — [Prelude/FlowSource.cs](/src/core/Flowthru.Core/Prelude/FlowSource.cs)
+
+The streaming sibling of `FlowIO<A>`: where `FlowIO<A>` describes a computation yielding *one* value-or-error, `FlowSource<A>` describes a lazy, resource-safe stream of *many* `A` values. Its defining rule is that its **only** consumption path is `.Compile()`, whose terminals (`Drain`, `Fold`, `ToList`) each return a `FlowIO`. Enumeration therefore always runs *inside* the effect envelope, so `FlowIO`'s guarantees extend to streams:
+
+- **Errors are values.** A mid-stream failure surfaces at compile as a terminal `RuntimeError`; it never escapes as a thrown exception into consumer code. `Attempt` moves failures in-band (`FlowSource<EffResult<A>>`) for dead-lettering, with `SkipErrors` / `Rethrow` to collapse back.
+- **Resources release deterministically.** The byte source is a `FlowResource` (below) acquired on the *first pull* and released on every exit path — completion, failure, cancellation. A source built but never run acquires nothing.
+- **Backpressure is pull-based.** A slow consumer paces a fast producer with no buffering, so a read → transform → write pipeline runs in bounded (`O(batch)`) memory rather than `O(file)`.
+
+This is why a streaming catalog read can process a dataset larger than RAM. The full rationale — including why we vendor a minimal `FlowSource` rather than take a LanguageExt dependency — is [ADR-0023](/.claude/docs/adr/0023-streaming-reads-as-catalog-item-type.md).
 
 #### `EffResult<A>` — [Prelude/EffResult.cs](/src/core/Flowthru.Core/Prelude/EffResult.cs)
 

--- a/examples/advanced/StreamingBulkLoad/.gitignore
+++ b/examples/advanced/StreamingBulkLoad/.gitignore
@@ -1,0 +1,27 @@
+# Flowthru cache manifest (framework-managed; safe to delete to force rebuild)
+.flowthru/
+
+# Generated metadata
+Metadata/
+
+# Ignore all generated data artifacts (Parquet, SQLite DB, CSV samples, report)
+Data/**
+
+# Un-ignore layer directories and their Schemas subdirectories so git can traverse them
+!Data/*/
+!Data/*/Schemas/
+
+# Allow raw input template files (the report template is checked in)
+!Data/_01_Raw/Templates/
+!Data/_01_Raw/Templates/*
+
+# Allow all schema and catalog .cs files
+!Data/**/*.cs
+
+# Un-ignore all .gitkeep files anywhere
+!**/.gitkeep
+
+# SQLite databases are generated
+*.db
+*.db-shm
+*.db-wal

--- a/examples/advanced/StreamingBulkLoad/Data/Catalog.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/Catalog.cs
@@ -1,0 +1,44 @@
+using Flowthru.Data.Catalog;
+using Microsoft.EntityFrameworkCore;
+
+namespace StreamingBulkLoad.Data;
+
+/// <summary>
+/// Catalog for the StreamingBulkLoad example. Binds the one raw Parquet dataset,
+/// the SQLite table both variants load into, and the self-measurement artefacts
+/// (the memory-sample CSV, its comparison summary, and the Markdown report).
+/// </summary>
+/// <remarks>
+/// The catalog owns the EF Core <see cref="DbContextOptions{TContext}"/> so every
+/// context — the eager item's, the streaming sink's, and the harness's
+/// clear/count contexts — targets the same SQLite file. It exposes
+/// <see cref="NewContext"/> for the factory-per-operation pattern rather than a
+/// shared instance.
+/// </remarks>
+public partial class Catalog : CatalogAbstract
+{
+  /// <summary>
+  /// Rows per Parquet row group on write. Deliberately small so a modest dataset
+  /// still spans many row groups — the streaming reader yields one group at a
+  /// time, so this is the knob that makes streaming's peak O(row group) rather
+  /// than O(file). Production defaults are 1,000,000.
+  /// </summary>
+  public const int WriteRowGroupSize = 10_000;
+
+  /// <summary>Rows per bulk-insert batch — the write-side batch for both variants.</summary>
+  public const int BulkBatchSize = 4_000;
+
+  private readonly string _basePath;
+  private readonly DbContextOptions<TransactionsDbContext> _dbOptions;
+
+  public Catalog(string basePath, string dbPath)
+  {
+    _basePath = basePath ?? throw new ArgumentNullException(nameof(basePath));
+    _dbOptions = new DbContextOptionsBuilder<TransactionsDbContext>()
+      .UseSqlite($"Data Source={dbPath}")
+      .Options;
+  }
+
+  /// <summary>A fresh context over the shared SQLite file — one per Load/Save/clear operation.</summary>
+  public TransactionsDbContext NewContext() => new(_dbOptions);
+}

--- a/examples/advanced/StreamingBulkLoad/Data/TransactionsDbContext.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/TransactionsDbContext.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+
+namespace StreamingBulkLoad.Data;
+
+/// <summary>
+/// SQLite-backed EF Core context holding the single <c>Transactions</c> table
+/// that both ingest variants load into. SQLite means the example runs with no
+/// external database — <c>EFCore.BulkExtensions</c> supports it — and the file
+/// is inspectable between runs.
+/// </summary>
+/// <remarks>
+/// The entity is <see cref="TransactionRecord"/>, the very same record used as
+/// the Parquet row schema. The key is assigned by the generator (dense 0..N-1)
+/// so it is value-generated-never: bulk insert writes the ids verbatim.
+/// </remarks>
+public class TransactionsDbContext : DbContext
+{
+  public TransactionsDbContext(DbContextOptions<TransactionsDbContext> options)
+    : base(options) { }
+
+  public DbSet<TransactionRecord> Transactions => Set<TransactionRecord>();
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<TransactionRecord>(entity =>
+    {
+      entity.ToTable("Transactions");
+      entity.HasKey(e => e.Id);
+      entity.Property(e => e.Id).ValueGeneratedNever();
+    });
+  }
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Catalog.Raw.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Catalog.Raw.cs
@@ -1,0 +1,51 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Data.Storage.Parquet;
+using Flowthru.Prelude;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Flows.StreamingIngest.Steps;
+
+namespace StreamingBulkLoad.Data;
+
+public partial class Catalog
+{
+  /// <summary>
+  /// The multi-row-group Parquet dataset both variants read. Written once by the
+  /// dataset generator with <see cref="WriteRowGroupSize"/>-row groups. In
+  /// production this file would live in object storage (S3) — a forward-only
+  /// stream that exercises the core make-seekable spill — but the streaming grain
+  /// is identical on a local file.
+  /// </summary>
+  public IItem<IEnumerable<TransactionRecord>> RawTransactions =>
+    CreateItem(() =>
+      ItemFactory.Enumerable.Parquet<TransactionRecord>(
+        "RawTransactions",
+        $"{_basePath}/_01_Raw/Datasets/transactions.parquet",
+        options: new ParquetItemOptions<TransactionRecord> { RowGroupSize = WriteRowGroupSize }));
+
+  /// <summary>
+  /// The streaming, transformed view of <see cref="RawTransactions"/>:
+  /// <c>.AsStream().Map(Normalize).Where(IsValid)</c> wrapped as a read-only Item
+  /// so <c>AddBulkLoad</c> can consume it on the DAG. O(batch) peak memory.
+  /// </summary>
+  public IReadOnlyItem<FlowSource<TransactionRecord>> CleanTransactionStream =>
+    new CleanTransactionStreamView("CleanTransactionStream", RawTransactions.AsStream());
+
+  /// <summary>
+  /// The measured facts, written by the harness in <c>Program.cs</c>: one row per
+  /// ingest variant. A Raw CSV so the Reporting Flow reads it like any other input.
+  /// </summary>
+  public IItem<IEnumerable<MemorySample>> MemorySamples =>
+    CreateItem(() =>
+      Item.Of<IEnumerable<MemorySample>>("MemorySamples")
+        .Csv()
+        .AtPath($"{_basePath}/_01_Raw/Datasets/memory_samples.csv")
+        .Build());
+
+  /// <summary>Markdown template for the memory report — <c>{{token}}</c> placeholders filled by the renderer step.</summary>
+  public IItem<string> MemoryReportTemplate =>
+    CreateItem(() =>
+      Item.Of<string>("MemoryReportTemplate")
+        .Text()
+        .AtPath($"{_basePath}/_01_Raw/Templates/memory_report.md")
+        .Build());
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Schemas/MemorySample.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Schemas/MemorySample.cs
@@ -1,0 +1,29 @@
+using Flowthru.Data.Schema;
+
+namespace StreamingBulkLoad.Data._01_Raw.Schemas;
+
+/// <summary>
+/// One measurement row emitted by the self-instrumenting harness in
+/// <c>Program.cs</c> — the peak memory an ingest variant held while loading the
+/// same Parquet dataset into the same SQLite schema. Persisted as a Raw CSV
+/// (<c>memory_samples.csv</c>) so the downstream Reporting Flow can read the
+/// facts back like any other Catalog Item and prove the example's own thesis.
+/// </summary>
+[FlowthruSchema]
+public partial record MemorySample
+{
+  /// <summary>Ingest variant: <c>Eager</c> or <c>Streaming</c>.</summary>
+  public required string Variant { get; init; }
+
+  /// <summary>Rows the variant loaded into the SQLite table (post-filter).</summary>
+  public required int RowCount { get; init; }
+
+  /// <summary>Peak OS working set observed during the variant's run, in bytes.</summary>
+  public required long PeakWorkingSetBytes { get; init; }
+
+  /// <summary>Peak managed heap (<c>GC.GetTotalMemory</c>) observed during the run, in bytes.</summary>
+  public required long PeakManagedBytes { get; init; }
+
+  /// <summary>Wall-clock duration of the variant's flow run, in milliseconds.</summary>
+  public required long DurationMs { get; init; }
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Schemas/TransactionRecord.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Schemas/TransactionRecord.cs
@@ -1,0 +1,44 @@
+using Flowthru.Data.Schema;
+
+namespace StreamingBulkLoad.Data._01_Raw.Schemas;
+
+/// <summary>
+/// One synthetic financial transaction. A single row type serves two roles so
+/// the eager and streaming ingest paths are apples-to-apples:
+/// <list type="bullet">
+///   <item>
+///     the <em>Parquet row schema</em> — <c>[FlowthruSchema]</c> generates the
+///     <c>IFlatSchema</c> / <c>IBinarySerializable</c> the Parquet serializer
+///     needs; and
+///   </item>
+///   <item>
+///     the <em>EF Core entity</em> persisted to the SQLite <c>Transactions</c>
+///     table (keyed on <see cref="Id"/>, value-generated-never).
+///   </item>
+/// </list>
+/// The record is written to Parquet once by the dataset generator, then read
+/// back two ways — eagerly (materialised into a <c>List</c>, O(file)) and via a
+/// streaming <c>FlowSource</c> (one row group at a time, O(batch)).
+/// </summary>
+[FlowthruSchema]
+public partial record TransactionRecord
+{
+  /// <summary>Dense surrogate key assigned by the generator (0..N-1). Used as the SQLite primary key.</summary>
+  public required int Id { get; init; }
+
+  /// <summary>Owning account. Low cardinality, so the column dictionary-encodes well in Parquet.</summary>
+  public required int AccountId { get; init; }
+
+  /// <summary>Signed amount in integer cents — avoids floating-point drift in a money column.</summary>
+  public required long AmountCents { get; init; }
+
+  /// <summary>
+  /// Free-text category as it arrives from the source — deliberately noisy
+  /// (mixed case, stray whitespace) so the streaming <c>.Map</c> normalisation
+  /// has something to do.
+  /// </summary>
+  public required string Category { get; init; }
+
+  /// <summary>Transaction timestamp in UTC.</summary>
+  public required DateTime TimestampUtc { get; init; }
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Templates/memory_report.md
+++ b/examples/advanced/StreamingBulkLoad/Data/_01_Raw/Templates/memory_report.md
@@ -1,0 +1,36 @@
+# Streaming vs. Eager Bulk Load — Memory Report
+
+> {{verdict}}
+
+Both variants read the **same** multi-row-group Parquet dataset, applied the
+**same** normalise + filter transform, and bulk-loaded the result into the
+**same** SQLite `Transactions` table — `{{row_count}}` rows each. The only
+difference is the memory grain: the eager path buffers the whole file
+(`O(file)`); the streaming path pulls one row group at a time and writes one
+batch at a time (`O(batch)`).
+
+## Peak memory
+
+| Variant   | Peak managed heap | Peak working set | Duration |
+|-----------|------------------:|-----------------:|---------:|
+| Eager     | {{eager_peak_managed_mb}} MB | {{eager_peak_ws_mb}} MB | {{eager_ms}} ms |
+| Streaming | {{streaming_peak_managed_mb}} MB | {{streaming_peak_ws_mb}} MB | {{streaming_ms}} ms |
+
+- **Managed-heap ratio:** streaming held peak to **{{managed_ratio_pct}}%** of eager.
+- **Working-set ratio:** streaming held peak to **{{ws_ratio_pct}}%** of eager.
+
+The managed-heap figure is the cleanest signal: eager keeps the whole decoded
+dataset live as a `List`, while streaming keeps only a row group plus one write
+batch. Working set is noisier (the runtime does not return pages to the OS
+promptly, and streaming is measured first so it also absorbs one-time
+JIT/assembly-load cost) — it is reported as a conservative, real-world number.
+
+## Why this matters
+
+On a memory-constrained host (AWS Lambda, a small ECS/Fargate container) the eager
+path's peak scales with the file and eventually OOMs — the #111 crash-loop. The
+streaming path's peak stays flat regardless of dataset size, so the same host
+loads an arbitrarily large dataset. See the README for how to watch the eager
+path OOM and the streaming path survive under `podman run --memory=…`.
+
+<sub>Generated {{generated_utc}} by the StreamingBulkLoad Reporting Flow.</sub>

--- a/examples/advanced/StreamingBulkLoad/Data/_02_Intermediate/Catalog.Intermediate.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_02_Intermediate/Catalog.Intermediate.cs
@@ -1,0 +1,51 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Extensions.EFCore.Bulk;
+using Flowthru.Prelude;
+using Microsoft.EntityFrameworkCore;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+
+namespace StreamingBulkLoad.Data;
+
+public partial class Catalog
+{
+  /// <summary>
+  /// The SQLite <c>Transactions</c> table as an <em>eager</em> bulk-write target.
+  /// Its Save <see cref="Enumerable.ToList{TSource}"/>s the whole dataset — the
+  /// very buffering the streaming path avoids — so peak memory is O(file), then
+  /// hands the materialised list to the shipped <see cref="BulkSave.Insert{T, TContext}"/>
+  /// helper inside a single transaction (so it commits once, the same way the
+  /// streaming sink does — the variants differ in <em>memory grain</em>, not in
+  /// how they talk to SQLite).
+  /// </summary>
+  public IItem<IEnumerable<TransactionRecord>> EagerTransactionsTable =>
+    CreateItem(() =>
+    {
+      var insert = BulkSave.Insert<TransactionRecord, TransactionsDbContext>(
+        new BulkSaveOptions { BatchSize = BulkBatchSize });
+
+      return ItemFactory.Enumerable.EFCore<TransactionRecord, TransactionsDbContext>(
+        "EagerTransactionsTable",
+        contextFactory: NewContext,
+        saveFunc: async (db, data, ct) =>
+        {
+          // Materialise the whole file into memory (the eager cost), then one
+          // transactional bulk insert.
+          var all = data as IList<TransactionRecord> ?? data.ToList();
+          await using var transaction = await db.Database.BeginTransactionAsync(ct);
+          await insert(db, all, ct);
+          await transaction.CommitAsync(ct);
+        });
+    });
+
+  /// <summary>
+  /// A fresh streaming bulk-insert sink over the same <c>Transactions</c> table.
+  /// Opens one transaction, writes one <see cref="BulkBatchSize"/>-row batch per
+  /// arriving chunk, commits on success (rolls back on mid-stream failure) — so
+  /// the write is O(batch). The streaming Flow's <c>AddBulkLoad</c> drives it.
+  /// A fresh sink per call because a sink is single-use (it owns a transaction).
+  /// </summary>
+  public IFlowSink<TransactionRecord> NewTransactionSink() =>
+    BulkSink.Insert<TransactionRecord, TransactionsDbContext>(
+      NewContext,
+      new BulkSaveOptions { BatchSize = BulkBatchSize });
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_03_Primary/Catalog.Primary.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_03_Primary/Catalog.Primary.cs
@@ -1,0 +1,15 @@
+using Flowthru.Data.Catalog;
+using StreamingBulkLoad.Data._03_Primary.Schemas;
+
+namespace StreamingBulkLoad.Data;
+
+public partial class Catalog
+{
+  /// <summary>
+  /// The computed eager-vs-streaming verdict (a one-row collection), held in
+  /// memory between the two Reporting Steps that produce and consume it.
+  /// </summary>
+  public IItem<IEnumerable<MemoryComparison>> MemoryComparisonSummary =>
+    CreateItem(() =>
+      Item.Of<IEnumerable<MemoryComparison>>("MemoryComparisonSummary").Memory().Build());
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_03_Primary/Schemas/MemoryComparison.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_03_Primary/Schemas/MemoryComparison.cs
@@ -1,0 +1,40 @@
+using Flowthru.Data.Schema;
+
+namespace StreamingBulkLoad.Data._03_Primary.Schemas;
+
+/// <summary>
+/// The eager-vs-streaming verdict computed from the two <c>MemorySample</c>
+/// rows — peaks in megabytes, the streaming/eager ratios, and durations.
+/// Produced by <c>SummarizeMemoryStep</c> and rendered into
+/// <c>memory_report.md</c> by <c>RenderMemoryReportStep</c>.
+/// </summary>
+[FlowthruSchema]
+public partial record MemoryComparison
+{
+  /// <summary>Valid rows loaded by both variants (they must match).</summary>
+  public required int RowCount { get; init; }
+
+  /// <summary>Eager peak managed heap, MB.</summary>
+  public required double EagerPeakManagedMb { get; init; }
+
+  /// <summary>Streaming peak managed heap, MB.</summary>
+  public required double StreamingPeakManagedMb { get; init; }
+
+  /// <summary>Eager peak working set, MB.</summary>
+  public required double EagerPeakWorkingSetMb { get; init; }
+
+  /// <summary>Streaming peak working set, MB.</summary>
+  public required double StreamingPeakWorkingSetMb { get; init; }
+
+  /// <summary>Streaming managed peak as a percentage of eager (lower is better).</summary>
+  public required double ManagedRatioPct { get; init; }
+
+  /// <summary>Streaming working-set peak as a percentage of eager.</summary>
+  public required double WorkingSetRatioPct { get; init; }
+
+  /// <summary>Eager run duration, ms.</summary>
+  public required long EagerDurationMs { get; init; }
+
+  /// <summary>Streaming run duration, ms.</summary>
+  public required long StreamingDurationMs { get; init; }
+}

--- a/examples/advanced/StreamingBulkLoad/Data/_04_Reporting/Catalog.Reporting.cs
+++ b/examples/advanced/StreamingBulkLoad/Data/_04_Reporting/Catalog.Reporting.cs
@@ -1,0 +1,18 @@
+using Flowthru.Data.Catalog;
+
+namespace StreamingBulkLoad.Data;
+
+public partial class Catalog
+{
+  /// <summary>
+  /// The headline artefact: a Markdown report contrasting eager and streaming
+  /// peak memory, the ratio, and a one-line verdict. Rendered from the template
+  /// and the comparison summary by <c>RenderMemoryReportStep</c>.
+  /// </summary>
+  public IItem<byte[]> MemoryReport =>
+    CreateItem(() =>
+      Item.Of<byte[]>("MemoryReport")
+        .Binary()
+        .AtPath($"{_basePath}/_04_Reporting/Datasets/memory_report.md")
+        .Build());
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/EagerIngest/EagerIngestFlow.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/EagerIngest/EagerIngestFlow.cs
@@ -1,0 +1,23 @@
+using Flowthru.Flow;
+using StreamingBulkLoad.Data;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Flows.EagerIngest.Steps;
+
+namespace StreamingBulkLoad.Flows.EagerIngest;
+
+/// <summary>
+/// The eager baseline: read the Parquet as a materialised <c>IEnumerable</c>
+/// (O(file)), normalise + filter, and bulk-write to SQLite in one shot. A single
+/// ordinary Step — the memory cost is entirely in the eager Load buffering the
+/// whole file before the transform ever runs.
+/// </summary>
+public static class EagerIngestFlow
+{
+  public static BuiltFlow Create(Catalog catalog) =>
+    FlowBuilder.CreateFlow("EagerIngest", flow =>
+      flow.AddStep<IEnumerable<TransactionRecord>, IEnumerable<TransactionRecord>>(
+        label: "NormalizeAndLoadEager",
+        transform: NormalizeTransactionsStep.Create(),
+        inputs: catalog.RawTransactions,
+        outputs: catalog.EagerTransactionsTable));
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/EagerIngest/Steps/NormalizeTransactionsStep.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/EagerIngest/Steps/NormalizeTransactionsStep.cs
@@ -1,0 +1,20 @@
+using Flowthru.Step;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Flows.Shared;
+
+namespace StreamingBulkLoad.Flows.EagerIngest.Steps;
+
+/// <summary>
+/// The eager transform: normalise then filter over a fully-materialised
+/// <c>IEnumerable</c>. Identical work to the streaming path's
+/// <c>.Map(Normalize).Where(IsValid)</c> — the difference is that its input is
+/// already an in-memory <c>List</c> (the eager Parquet Load buffered the whole
+/// file), so peak memory is O(file). Deferred LINQ here changes nothing: the
+/// backing list is resident for the life of the downstream bulk insert.
+/// </summary>
+[FlowthruStep]
+public static class NormalizeTransactionsStep
+{
+  public static Func<IEnumerable<TransactionRecord>, IEnumerable<TransactionRecord>> Create() =>
+    rows => rows.Select(TransactionCleaning.Normalize).Where(TransactionCleaning.IsValid);
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/Reporting/ReportingFlow.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/Reporting/ReportingFlow.cs
@@ -1,0 +1,32 @@
+using Flowthru.Flow;
+using StreamingBulkLoad.Data;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Data._03_Primary.Schemas;
+using StreamingBulkLoad.Flows.Reporting.Steps;
+
+namespace StreamingBulkLoad.Flows.Reporting;
+
+/// <summary>
+/// The example proving its own thesis: read the memory samples the harness
+/// measured (a Raw CSV), summarise the eager-vs-streaming verdict, and render it
+/// into <c>Data/_04_Reporting/memory_report.md</c>. Pure Flowthru C# Steps — the
+/// analytical workload here is the example's own instrumentation.
+/// </summary>
+public static class ReportingFlow
+{
+  public static BuiltFlow Create(Catalog catalog) =>
+    FlowBuilder.CreateFlow("Reporting", flow =>
+    {
+      flow.AddStep<IEnumerable<MemorySample>, IEnumerable<MemoryComparison>>(
+        label: "SummarizeMemory",
+        transform: SummarizeMemoryStep.Create(),
+        inputs: catalog.MemorySamples,
+        outputs: catalog.MemoryComparisonSummary);
+
+      flow.AddStep<IEnumerable<MemoryComparison>, string, byte[]>(
+        label: "RenderMemoryReport",
+        transform: RenderMemoryReportStep.Create(),
+        inputs: (catalog.MemoryComparisonSummary, catalog.MemoryReportTemplate),
+        outputs: catalog.MemoryReport);
+    });
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/Reporting/Steps/RenderMemoryReportStep.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/Reporting/Steps/RenderMemoryReportStep.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using System.Text;
+using Flowthru.Step;
+using StreamingBulkLoad.Data._03_Primary.Schemas;
+
+namespace StreamingBulkLoad.Flows.Reporting.Steps;
+
+/// <summary>
+/// Fill the Markdown template with the computed verdict. Structure and prose
+/// live in the template (a Raw Catalog Item); this step only substitutes
+/// <c>{{token}}</c> placeholders, so re-shaping the report is a template edit,
+/// not a code change.
+/// </summary>
+[FlowthruStep]
+public static class RenderMemoryReportStep
+{
+  public static Func<(IEnumerable<MemoryComparison>, string), byte[]> Create()
+  {
+    return inputs =>
+    {
+      var (comparisons, template) = inputs;
+      var c = comparisons.First();
+      var ci = CultureInfo.InvariantCulture;
+
+      string Mb(double v) => v.ToString("0.0", ci);
+      string Pct(double v) => v.ToString("0.0", ci);
+
+      var verdict =
+        $"Streaming held peak managed memory to **{Pct(c.ManagedRatioPct)}%** of eager "
+        + $"({Mb(c.StreamingPeakManagedMb)} MB vs {Mb(c.EagerPeakManagedMb)} MB) while loading the same "
+        + $"{c.RowCount.ToString("N0", ci)} rows into SQLite.";
+
+      var subs = new Dictionary<string, string>(StringComparer.Ordinal)
+      {
+        ["row_count"] = c.RowCount.ToString("N0", ci),
+        ["eager_peak_managed_mb"] = Mb(c.EagerPeakManagedMb),
+        ["streaming_peak_managed_mb"] = Mb(c.StreamingPeakManagedMb),
+        ["managed_ratio_pct"] = Pct(c.ManagedRatioPct),
+        ["eager_peak_ws_mb"] = Mb(c.EagerPeakWorkingSetMb),
+        ["streaming_peak_ws_mb"] = Mb(c.StreamingPeakWorkingSetMb),
+        ["ws_ratio_pct"] = Pct(c.WorkingSetRatioPct),
+        ["eager_ms"] = c.EagerDurationMs.ToString("N0", ci),
+        ["streaming_ms"] = c.StreamingDurationMs.ToString("N0", ci),
+        ["verdict"] = verdict,
+        ["generated_utc"] = DateTime.UtcNow.ToString("u", ci),
+      };
+
+      var rendered = template;
+      foreach (var (token, value) in subs)
+      {
+        rendered = rendered.Replace("{{" + token + "}}", value);
+      }
+
+      return Encoding.UTF8.GetBytes(rendered);
+    };
+  }
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/Reporting/Steps/SummarizeMemoryStep.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/Reporting/Steps/SummarizeMemoryStep.cs
@@ -1,0 +1,49 @@
+using Flowthru.Step;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Data._03_Primary.Schemas;
+
+namespace StreamingBulkLoad.Flows.Reporting.Steps;
+
+/// <summary>
+/// Reduce the two raw <see cref="MemorySample"/> rows to a single
+/// <see cref="MemoryComparison"/> verdict: peaks in MB, streaming/eager ratios,
+/// and durations. Pure — the arithmetic the report needs, computed once.
+/// </summary>
+[FlowthruStep]
+public static class SummarizeMemoryStep
+{
+  private const double BytesPerMb = 1024.0 * 1024.0;
+
+  public static Func<IEnumerable<MemorySample>, IEnumerable<MemoryComparison>> Create()
+  {
+    return samples =>
+    {
+      var byVariant = samples.ToDictionary(s => s.Variant, StringComparer.OrdinalIgnoreCase);
+      var eager = byVariant["Eager"];
+      var streaming = byVariant["Streaming"];
+
+      var eagerManagedMb = eager.PeakManagedBytes / BytesPerMb;
+      var streamingManagedMb = streaming.PeakManagedBytes / BytesPerMb;
+      var eagerWorkingSetMb = eager.PeakWorkingSetBytes / BytesPerMb;
+      var streamingWorkingSetMb = streaming.PeakWorkingSetBytes / BytesPerMb;
+
+      return new[]
+      {
+        new MemoryComparison
+        {
+          RowCount = eager.RowCount,
+          EagerPeakManagedMb = Round(eagerManagedMb),
+          StreamingPeakManagedMb = Round(streamingManagedMb),
+          EagerPeakWorkingSetMb = Round(eagerWorkingSetMb),
+          StreamingPeakWorkingSetMb = Round(streamingWorkingSetMb),
+          ManagedRatioPct = eagerManagedMb > 0 ? Round(100.0 * streamingManagedMb / eagerManagedMb) : 0,
+          WorkingSetRatioPct = eagerWorkingSetMb > 0 ? Round(100.0 * streamingWorkingSetMb / eagerWorkingSetMb) : 0,
+          EagerDurationMs = eager.DurationMs,
+          StreamingDurationMs = streaming.DurationMs,
+        },
+      };
+    };
+  }
+
+  private static double Round(double value) => Math.Round(value, 1);
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/Shared/TransactionCleaning.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/Shared/TransactionCleaning.cs
@@ -1,0 +1,34 @@
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+
+namespace StreamingBulkLoad.Flows.Shared;
+
+/// <summary>
+/// The one stateless transform both ingest variants apply, factored out so the
+/// eager and streaming paths are provably identical work — only the memory
+/// grain differs. <see cref="Normalize"/> is the <c>.Map</c>; <see cref="IsValid"/>
+/// is the <c>.Where</c>.
+/// </summary>
+/// <remarks>
+/// Stateless and row-local by construction: neither function looks beyond the
+/// single row it is handed, which is exactly why the work composes as lazy
+/// streaming combinators (<c>source.Map(Normalize).Where(IsValid)</c>) with no
+/// buffering. A transform that needed to see the whole dataset (a group-by, a
+/// sort) would instead consume the eager view — see the README.
+/// </remarks>
+public static class TransactionCleaning
+{
+  /// <summary>
+  /// Canonicalise the noisy category text (trim, upper-case). Returns a new
+  /// record — pure, allocation-per-row, no shared state.
+  /// </summary>
+  public static TransactionRecord Normalize(TransactionRecord row) =>
+    row with { Category = (row.Category ?? string.Empty).Trim().ToUpperInvariant() };
+
+  /// <summary>
+  /// Drop rows a downstream consumer would reject: zero-amount placeholders and
+  /// rows with no category. The generator injects a fixed fraction of these so
+  /// the filter demonstrably removes the same count on both paths.
+  /// </summary>
+  public static bool IsValid(TransactionRecord row) =>
+    row.AmountCents != 0 && !string.IsNullOrWhiteSpace(row.Category);
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/StreamingIngest/Steps/CleanTransactionStreamView.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/StreamingIngest/Steps/CleanTransactionStreamView.cs
@@ -1,0 +1,74 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Data.Storage;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Flows.Shared;
+
+namespace StreamingBulkLoad.Flows.StreamingIngest.Steps;
+
+/// <summary>
+/// A read-only streaming Catalog Item that layers the stateless
+/// <see cref="TransactionCleaning"/> transform onto a raw
+/// <c>FlowSource&lt;TransactionRecord&gt;</c> view — i.e. it is
+/// <c>raw.AsStream().Map(Normalize).Where(IsValid)</c> expressed as an Item so
+/// it can be handed to <c>FlowBuilder.AddBulkLoad(...)</c> on the DAG.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why an Item wrapper rather than an inline call: the streaming combinators
+/// (<c>Map</c>/<c>Where</c>) live on <see cref="FlowSource{A}"/>, not on the
+/// <c>IReadOnlyItem</c> that <c>.AsStream()</c> returns, and the on-DAG bulk-load
+/// helper takes an <em>item</em> (<c>IReadOnlyItem&lt;FlowSource&lt;T&gt;&gt;</c>),
+/// not a bare source. Wrapping the transformed source back up as a read-only
+/// item is the seam that keeps the load on the DAG — scheduled, pre-flighted,
+/// under the read cap — while still applying the transform.
+/// </para>
+/// <para>
+/// Everything stays lazy: <see cref="Load"/> only <em>describes</em> the mapped
+/// stream; no row is pulled until <c>AddBulkLoad</c>'s sink compiles and drains
+/// it one row group at a time. Peak memory is O(batch), same as the untransformed
+/// path. Node-level concerns (existence, inspection, fingerprint) delegate to the
+/// inner view, which delegates to the eager Parquet origin.
+/// </para>
+/// </remarks>
+public sealed class CleanTransactionStreamView : IReadOnlyItem<FlowSource<TransactionRecord>>
+{
+  private readonly IReadOnlyItem<FlowSource<TransactionRecord>> _inner;
+
+  /// <summary>
+  /// Wrap a raw streaming view (from <c>rawParquetItem.AsStream()</c>) with the
+  /// normalise-then-filter transform.
+  /// </summary>
+  public CleanTransactionStreamView(string label, IReadOnlyItem<FlowSource<TransactionRecord>> inner)
+  {
+    Label = label ?? throw new ArgumentNullException(nameof(label));
+    _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+  }
+
+  public string Label { get; }
+  public NodeTraits Traits => _inner.Traits;
+  public Type DataType => typeof(FlowSource<TransactionRecord>);
+
+  /// <summary>Describe the transformed stream — the streaming combinators applied lazily.</summary>
+  public FlowIO<FlowSource<TransactionRecord>> Load() =>
+    _inner.Load().Map(source =>
+      source
+        .Map(TransactionCleaning.Normalize)
+        .Where(TransactionCleaning.IsValid));
+
+  public FlowIO<FlowUnit> Save(FlowSource<TransactionRecord> data) =>
+    FlowIO.Fail<FlowUnit>(new RuntimeError.External(
+      $"CleanTransactionStreamView[{Label}].Save",
+      new InvalidOperationException(
+        $"'{Label}' is a read-only streaming view — write through the eager Parquet item instead.")));
+
+  public FlowIO<bool> Exists() => _inner.Exists();
+  public FlowIO<ValidationResult> InspectShallow(int sampleSize = 100) => _inner.InspectShallow(sampleSize);
+  public FlowIO<ValidationResult> InspectDeep() => _inner.InspectDeep();
+  public FlowIO<ValidationResult> InspectTarget() => _inner.InspectTarget();
+  public FlowIO<ValidationResult> Validate() => _inner.Validate();
+
+  public FlowIO<object> LoadUntyped() => Load().Map(value => (object)value!);
+  public FlowIO<FlowUnit> SaveUntyped(object data) => Save((FlowSource<TransactionRecord>)data);
+}

--- a/examples/advanced/StreamingBulkLoad/Flows/StreamingIngest/StreamingIngestFlow.cs
+++ b/examples/advanced/StreamingBulkLoad/Flows/StreamingIngest/StreamingIngestFlow.cs
@@ -1,0 +1,28 @@
+using Flowthru.Flow;
+using StreamingBulkLoad.Data;
+
+namespace StreamingBulkLoad.Flows.StreamingIngest;
+
+/// <summary>
+/// The streaming path: pull the same Parquet one row group at a time, apply the
+/// same normalise + filter as lazy <c>FlowSource</c> combinators, and bulk-write
+/// to the same SQLite table batch-by-batch inside one transaction (O(batch)).
+/// The whole load is a single on-DAG <c>AddBulkLoad</c> — scheduled, pre-flighted,
+/// and under the read cap like any other Step.
+/// </summary>
+/// <remarks>
+/// The transform lives in <c>catalog.CleanTransactionStream</c>
+/// (<c>.AsStream().Map(Normalize).Where(IsValid)</c>); <c>AddBulkLoad</c> wires
+/// that streaming view straight into the EF Core bulk sink. This is the runnable
+/// shape of the #111 downstream case: a large dataset loaded on a
+/// memory-constrained host without buffering the whole thing.
+/// </remarks>
+public static class StreamingIngestFlow
+{
+  public static BuiltFlow Create(Catalog catalog) =>
+    FlowBuilder.CreateFlow("StreamingIngest", flow =>
+      flow.AddBulkLoad(
+        source: catalog.CleanTransactionStream,
+        sink: catalog.NewTransactionSink(),
+        label: "StreamTransactionsToSqlite"));
+}

--- a/examples/advanced/StreamingBulkLoad/Program.cs
+++ b/examples/advanced/StreamingBulkLoad/Program.cs
@@ -1,0 +1,324 @@
+using System.Diagnostics;
+using System.Globalization;
+using Flowthru.Flow;
+using Flowthru.Prelude;
+using Microsoft.EntityFrameworkCore;
+using StreamingBulkLoad.Data;
+using StreamingBulkLoad.Data._01_Raw.Schemas;
+using StreamingBulkLoad.Flows.EagerIngest;
+using StreamingBulkLoad.Flows.Reporting;
+using StreamingBulkLoad.Flows.StreamingIngest;
+
+namespace StreamingBulkLoad;
+
+/// <summary>
+/// Self-instrumenting entry point. Unlike the CLI-driven examples, this harness
+/// wraps each ingest variant in a background RSS sampler so it can measure — in
+/// this very process — the peak memory eager and streaming ingest each hold
+/// while loading the same Parquet dataset into the same SQLite schema. It then
+/// runs a pure-Flowthru Reporting Flow over the samples to emit the verdict.
+/// </summary>
+/// <remarks>
+/// Sequence: generate (once) → warm up → measure Streaming → measure Eager →
+/// write <c>memory_samples.csv</c> → run the Reporting Flow → print the numbers.
+/// Streaming is measured first, from a clean low baseline, because the OS does
+/// not hand working-set back after the eager path balloons it.
+/// </remarks>
+public static class Program
+{
+  private const int DefaultRows = 200_000;
+
+  // One in this many generated rows is invalid (zero amount) so the filter
+  // demonstrably drops the same count on both paths.
+  private const int InvalidEveryNth = 50;
+
+  public static async Task<int> Main(string[] args)
+  {
+    var rows = ResolveRowCount(args);
+    var generateOnly = args.Contains("--generate");
+    var dryRun = args.Contains("--dry-run");
+
+    var cwd = Directory.GetCurrentDirectory();
+    var dataDir = Path.Combine(cwd, "Data");
+    var dbPath = Path.Combine(dataDir, "_02_Intermediate", "transactions.db");
+    var parquetPath = Path.Combine(dataDir, "_01_Raw", "Datasets", "transactions.parquet");
+
+    EnsureDirectories(dataDir);
+
+    if (dryRun)
+    {
+      Console.WriteLine("StreamingBulkLoad --dry-run: EagerIngest, StreamingIngest, Reporting flows registered. No compute.");
+      return 0;
+    }
+
+    var catalog = new Catalog(dataDir, dbPath);
+
+    if (generateOnly || !File.Exists(parquetPath))
+    {
+      await GenerateDatasetAsync(catalog, rows);
+      if (generateOnly)
+      {
+        return 0;
+      }
+    }
+
+    EnsureDatabase(catalog);
+
+    // Warm up the ingest code paths (JIT, Parquet reader, EF bulk) so the
+    // first measured run isn't charged for one-time startup cost.
+    Console.WriteLine("Warming up ingest paths...");
+    ClearTable(catalog);
+    await RunFlowOrThrow(StreamingIngestFlow.Create(catalog), "warmup streaming ingest");
+
+    Console.WriteLine($"\nMeasuring ingest of {rows:N0} rows ({Catalog.WriteRowGroupSize:N0}-row Parquet groups, {Catalog.BulkBatchSize:N0}-row bulk batches)...\n");
+
+    var streamingSample = await MeasureVariantAsync(
+      "Streaming", catalog, () => StreamingIngestFlow.Create(catalog));
+    PrintSample(streamingSample);
+
+    var eagerSample = await MeasureVariantAsync(
+      "Eager", catalog, () => EagerIngestFlow.Create(catalog));
+    PrintSample(eagerSample);
+
+    // Persist the measured facts as a Raw CSV, then let a pure Flowthru Flow
+    // read them back and render the report — the example proving its own thesis.
+    await RunIoOrThrow(
+      catalog.MemorySamples.Save(new[] { eagerSample, streamingSample }),
+      "write memory_samples.csv");
+
+    await RunFlowOrThrow(ReportingFlow.Create(catalog), "reporting");
+
+    PrintFinalSummary(eagerSample, streamingSample, dataDir);
+    return 0;
+  }
+
+  // ── Measurement ────────────────────────────────────────────────────────
+
+  private static async Task<MemorySample> MeasureVariantAsync(
+    string variant,
+    Catalog catalog,
+    Func<BuiltFlow> buildFlow)
+  {
+    ClearTable(catalog);
+
+    // Establish a clean managed baseline so the in-window peak reflects this
+    // variant's own allocations.
+    GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+    GC.WaitForPendingFinalizers();
+    GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+    using var sampler = new RssSampler();
+    sampler.Start();
+    var stopwatch = Stopwatch.StartNew();
+
+    var result = await buildFlow().RunAsync();
+
+    stopwatch.Stop();
+    sampler.Stop();
+
+    if (!result.IsSuccess)
+    {
+      var failure = result.FirstFailure;
+      throw new InvalidOperationException(
+        $"{variant} ingest failed: {failure?.Error?.ToString() ?? "unknown error"}");
+    }
+
+    var rowCount = CountRows(catalog);
+
+    return new MemorySample
+    {
+      Variant = variant,
+      RowCount = rowCount,
+      PeakWorkingSetBytes = sampler.PeakWorkingSetBytes,
+      PeakManagedBytes = sampler.PeakManagedBytes,
+      DurationMs = stopwatch.ElapsedMilliseconds,
+    };
+  }
+
+  /// <summary>
+  /// Background sampler tracking the peak OS working set and managed heap over a
+  /// measurement window. Polls every 25 ms — fast enough to catch a transient
+  /// O(file) spike, cheap enough not to perturb the run.
+  /// </summary>
+  private sealed class RssSampler : IDisposable
+  {
+    private readonly Process _process = Process.GetCurrentProcess();
+    private volatile bool _running;
+    private Thread? _thread;
+
+    public long PeakWorkingSetBytes { get; private set; }
+    public long PeakManagedBytes { get; private set; }
+
+    public void Start()
+    {
+      _process.Refresh();
+      PeakWorkingSetBytes = _process.WorkingSet64;
+      PeakManagedBytes = GC.GetTotalMemory(forceFullCollection: false);
+      _running = true;
+      _thread = new Thread(Loop) { IsBackground = true, Name = "rss-sampler" };
+      _thread.Start();
+    }
+
+    private void Loop()
+    {
+      while (_running)
+      {
+        Observe();
+        Thread.Sleep(25);
+      }
+    }
+
+    private void Observe()
+    {
+      _process.Refresh();
+      var workingSet = _process.WorkingSet64;
+      if (workingSet > PeakWorkingSetBytes) PeakWorkingSetBytes = workingSet;
+      var managed = GC.GetTotalMemory(forceFullCollection: false);
+      if (managed > PeakManagedBytes) PeakManagedBytes = managed;
+    }
+
+    public void Stop()
+    {
+      _running = false;
+      _thread?.Join();
+      Observe();
+    }
+
+    public void Dispose()
+    {
+      _running = false;
+      _process.Dispose();
+    }
+  }
+
+  // ── Dataset generation ───────────────────────────────────────────────────
+
+  private static async Task GenerateDatasetAsync(Catalog catalog, int rows)
+  {
+    Console.WriteLine($"Generating {rows:N0}-row multi-row-group Parquet dataset...");
+    await RunIoOrThrow(catalog.RawTransactions.Save(GenerateRows(rows)), "generate transactions.parquet");
+    Console.WriteLine("Dataset written to Data/_01_Raw/Datasets/transactions.parquet");
+  }
+
+  private static IEnumerable<TransactionRecord> GenerateRows(int count)
+  {
+    // Deterministic seed so re-runs produce the same dataset (stable report).
+    var random = new Random(12345);
+    var baseTime = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // Noisy source categories — mixed case and stray whitespace — so the
+    // streaming .Map normalisation has real work to do.
+    string[] categories =
+    {
+      " groceries ", "RENT", "utilities", " Travel", "dining ", "Salary", "  Fees",
+    };
+
+    for (var i = 0; i < count; i++)
+    {
+      var invalid = i % InvalidEveryNth == 0;
+      yield return new TransactionRecord
+      {
+        Id = i,
+        AccountId = 1_000 + (i % 5_000),
+        AmountCents = invalid ? 0 : random.Next(-50_000, 500_000),
+        Category = categories[i % categories.Length],
+        TimestampUtc = baseTime.AddSeconds(i),
+      };
+    }
+  }
+
+  // ── SQLite helpers ───────────────────────────────────────────────────────
+
+  private static void EnsureDatabase(Catalog catalog)
+  {
+    using var db = catalog.NewContext();
+    db.Database.EnsureCreated();
+  }
+
+  private static void ClearTable(Catalog catalog)
+  {
+    using var db = catalog.NewContext();
+    db.Transactions.ExecuteDelete();
+  }
+
+  private static int CountRows(Catalog catalog)
+  {
+    using var db = catalog.NewContext();
+    return db.Transactions.Count();
+  }
+
+  // ── Plumbing ─────────────────────────────────────────────────────────────
+
+  private static int ResolveRowCount(string[] args)
+  {
+    for (var i = 0; i < args.Length - 1; i++)
+    {
+      if (args[i] == "--rows" && int.TryParse(args[i + 1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0)
+      {
+        return parsed;
+      }
+    }
+
+    var env = Environment.GetEnvironmentVariable("STREAMINGBULKLOAD_ROWS");
+    if (int.TryParse(env, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fromEnv) && fromEnv > 0)
+    {
+      return fromEnv;
+    }
+
+    return DefaultRows;
+  }
+
+  private static void EnsureDirectories(string dataDir)
+  {
+    Directory.CreateDirectory(Path.Combine(dataDir, "_01_Raw", "Datasets"));
+    Directory.CreateDirectory(Path.Combine(dataDir, "_01_Raw", "Templates"));
+    Directory.CreateDirectory(Path.Combine(dataDir, "_02_Intermediate"));
+    Directory.CreateDirectory(Path.Combine(dataDir, "_04_Reporting", "Datasets"));
+  }
+
+  private static async Task RunFlowOrThrow(BuiltFlow flow, string what)
+  {
+    var result = await flow.RunAsync();
+    if (!result.IsSuccess)
+    {
+      var failure = result.FirstFailure;
+      throw new InvalidOperationException($"{what} failed: {failure?.Error?.ToString() ?? "unknown error"}");
+    }
+  }
+
+  private static async Task RunIoOrThrow(FlowIO<FlowUnit> io, string what)
+  {
+    var result = await io.Run();
+    if (result is EffResult<FlowUnit>.Failure failure)
+    {
+      throw new InvalidOperationException($"{what} failed: {failure.Error}");
+    }
+  }
+
+  // ── Console output ───────────────────────────────────────────────────────
+
+  private static void PrintSample(MemorySample sample)
+  {
+    Console.WriteLine(
+      $"  {sample.Variant,-9} | rows {sample.RowCount,10:N0} | peak managed {Mb(sample.PeakManagedBytes),8:N1} MB "
+      + $"| peak working set {Mb(sample.PeakWorkingSetBytes),8:N1} MB | {sample.DurationMs,6:N0} ms");
+  }
+
+  private static void PrintFinalSummary(MemorySample eager, MemorySample streaming, string dataDir)
+  {
+    var ratio = eager.PeakManagedBytes > 0
+      ? 100.0 * streaming.PeakManagedBytes / eager.PeakManagedBytes
+      : 0.0;
+
+    Console.WriteLine();
+    Console.WriteLine("──────────────────────────────────────────────────────────────");
+    Console.WriteLine($"  Eager peak managed:     {Mb(eager.PeakManagedBytes),8:N1} MB");
+    Console.WriteLine($"  Streaming peak managed: {Mb(streaming.PeakManagedBytes),8:N1} MB");
+    Console.WriteLine($"  Streaming held peak to {ratio:N1}% of eager (both loaded {eager.RowCount:N0} rows).");
+    Console.WriteLine("──────────────────────────────────────────────────────────────");
+    Console.WriteLine($"  Report: {Path.Combine(dataDir, "_04_Reporting", "Datasets", "memory_report.md")}");
+    Console.WriteLine();
+  }
+
+  private static double Mb(long bytes) => bytes / (1024.0 * 1024.0);
+}

--- a/examples/advanced/StreamingBulkLoad/README.md
+++ b/examples/advanced/StreamingBulkLoad/README.md
@@ -1,0 +1,130 @@
+# StreamingBulkLoad Advanced
+
+> [!NOTE]
+> How do I bulk-load a large Parquet dataset into a database on a memory-constrained host without buffering the whole file?
+
+This project demonstrates streaming a multi-row-group Parquet dataset into SQLite one row group at a time — O(batch) peak memory — and measures the win against the eager O(file) path over the very same data.
+
+This project:
+
+- Generates a synthetic multi-row-group Parquet dataset (row count is a knob) and reads it back two ways into the **same** SQLite schema — an **eager** Flow (materialise the whole file, then bulk-write) and a **streaming** Flow (`.AsStream().Map(...).Where(...)` into an `AddBulkLoad` sink).
+- Instruments itself: a background working-set sampler wraps each ingest variant and records peak memory to a Raw CSV, which a pure-Flowthru **Reporting** Flow reads back to render `memory_report.md` — the example proves its own thesis.
+- Frames the production shape: the constrained-host story where the eager path OOMs and the streaming path survives, and where the Parquet would arrive forward-only from S3.
+
+**This is not a template** — `dotnet new` does not scaffold it, and the harness in `Program.cs` is bespoke self-measurement rather than the standard CLI host. It is the runnable, teachable form of the downstream case that motivated the streaming milestone ([#111](https://github.com/chaoticgoodcomputing/flowthru/issues/111)). Assumes you've worked through [SpaceflightsEFCore](../../starter/SpaceflightsEFCore/) and [FlowthruCoverage](../FlowthruCoverage/).
+
+## Getting Started
+
+Runs with no external database — SQLite via `EFCore.BulkExtensions`, and the dataset is generated on first run. From this directory:
+
+```bash
+nx run StreamingBulkLoad:run       # or: dotnet run
+```
+
+Crank the dataset up (wider memory gap, longer runtime), then run:
+
+```bash
+STREAMINGBULKLOAD_ROWS=2000000 ./scripts/generate-dataset.sh   # or: nx run StreamingBulkLoad:generate
+dotnet run
+```
+
+Success looks like the verdict printed to the console and written to [`Data/_04_Reporting/Datasets/memory_report.md`](./Data/_04_Reporting/Datasets/memory_report.md) — at the 200,000-row default, streaming holds peak managed memory to ~15% of eager while both load the same 196,000 rows into [`Data/_02_Intermediate/transactions.db`](./Data/_02_Intermediate/).
+
+To watch the constrained-host story directly, cap the process and run the eager path alone under a ceiling it cannot fit — it OOMs, while streaming survives the same cap:
+
+```bash
+# Eager peak scales with the file; streaming peak stays flat. Crank rows high,
+# then cap the process memory (mirrors tests/extensions/CONTRIBUTING.md).
+podman run --rm --memory=256m -v "$PWD/../../..":/work -w /work/examples/advanced/StreamingBulkLoad \
+  mcr.microsoft.com/dotnet/sdk:10.0 \
+  bash -c 'STREAMINGBULKLOAD_ROWS=5000000 dotnet run'
+```
+
+## Concepts
+
+> **Reminder:** the patterns below show how the streaming primitives compose on a real workload, **not** a template to clone. The harness, schema, and measurement wiring are specific to this demonstration.
+
+- **[Streaming ingest with `.AsStream()` + `AddBulkLoad`](./Flows/StreamingIngest/StreamingIngestFlow.cs):** the whole load is one on-DAG step — the streaming Parquet view drives an EF Core bulk sink batch-by-batch inside one transaction, so peak memory is O(batch) no matter how large the file. This is the runnable form of the #111 downstream case.
+- **[Lazy `.Map` / `.Where` streaming combinators](./Flows/StreamingIngest/Steps/CleanTransactionStreamView.cs):** the normalise + filter transform is applied as lazy `FlowSource` combinators over the stream, wrapped as a read-only Catalog Item so `AddBulkLoad` consumes it on the DAG. No row is pulled until the sink drains it.
+- **[Eager and streaming as a per-edge wiring choice](./Flows/EagerIngest/EagerIngestFlow.cs):** the same [normalise + filter](./Flows/Shared/TransactionCleaning.cs) runs on both paths over the same schema — the eager Flow consumes the materialised `IEnumerable` (O(file)); the streaming Flow consumes the `.AsStream()` view (O(batch)). The transform code is byte-for-byte identical; only the grain differs.
+- **[EFCore.Bulk streaming sink](./Data/_02_Intermediate/Catalog.Intermediate.cs):** `BulkSink.Insert<T, TContext>` opens one transaction, bulk-inserts one batch per arriving chunk, and commits on success — rolling back the whole write on a mid-stream failure, so O(batch) memory and all-or-nothing stay honest together.
+- **[Multi-row-group Parquet as the streaming knob](./Data/_01_Raw/Catalog.Raw.cs):** the dataset is written with small (10,000-row) row groups so a modest file still spans many groups. The streaming reader yields one group at a time — the row-group size is what bounds streaming's peak.
+- **[Self-measurement via a background RSS sampler](./Program.cs):** `Program.cs` polls `Process.WorkingSet64` and `GC.GetTotalMemory` on a background thread while each variant runs, tracks the peak, and writes `{ Variant, RowCount, PeakWorkingSetBytes, PeakManagedBytes, DurationMs }` to a Raw CSV.
+- **[The example proving its own thesis](./Flows/Reporting/ReportingFlow.cs):** a pure-Flowthru Reporting Flow reads the measurement CSV back like any other input, summarises the eager-vs-streaming verdict, and renders it from a [checked-in Markdown template](./Data/_01_Raw/Templates/memory_report.md) — the same self-analysing shape as FlowthruCoverage.
+- **Constrained-host framing:** in production this Parquet arrives forward-only from S3 (the seekable-spill path), and the host is a small Lambda or lightweight ECS/Fargate container. The eager path's peak grows with the file until it OOMs; streaming's stays flat — run it under `podman run --memory=…` to see the difference.
+
+## Structure
+
+### Diagram
+
+The three Flows over one shared SQLite schema: two ingest variants and the self-measurement report.
+
+<!-- flowthru:mermaid:start -->
+```mermaid
+flowchart TB
+
+    %% External Data Inputs
+    RawTransactions[("RawTransactions<br>(Parquet)")]
+    MemoryReportTemplate[("MemoryReportTemplate")]
+
+    subgraph EagerIngest["EagerIngest — O(file)"]
+        NormalizeAndLoadEager["NormalizeAndLoadEager"]
+        EagerTransactionsTable[("Transactions (SQLite)")]
+    end
+
+    subgraph StreamingIngest["StreamingIngest — O(batch)"]
+        CleanTransactionStream[("CleanTransactionStream<br>.AsStream().Map().Where()")]
+        StreamTransactionsToSqlite["StreamTransactionsToSqlite<br>AddBulkLoad → BulkSink.Insert"]
+    end
+
+    subgraph Reporting["Reporting"]
+        MemorySamples[("memory_samples.csv")]
+        SummarizeMemory["SummarizeMemory"]
+        MemoryComparisonSummary[("MemoryComparisonSummary")]
+        RenderMemoryReport["RenderMemoryReport"]
+        MemoryReport[("memory_report.md")]
+    end
+
+    RawTransactions --> NormalizeAndLoadEager --> EagerTransactionsTable
+    RawTransactions --> CleanTransactionStream --> StreamTransactionsToSqlite
+    MemorySamples --> SummarizeMemory --> MemoryComparisonSummary
+    MemoryComparisonSummary --> RenderMemoryReport
+    MemoryReportTemplate --> RenderMemoryReport
+    RenderMemoryReport --> MemoryReport
+```
+<!-- flowthru:mermaid:end -->
+
+### Files
+
+<!-- flowthru:filetree:start -->
+```
+StreamingBulkLoad/
+├── Program.cs  # entry point
+├── Data/
+│   ├── TransactionsDbContext.cs
+│   ├── _01_Raw/
+│   │   ├── Schemas/
+│   │   │   ├── MemorySample.cs
+│   │   │   └── TransactionRecord.cs
+│   │   └── Templates/
+│   │       └── memory_report.md
+│   ├── ...
+│   └── _04_Reporting/
+│       └── (memory_report.md — generated)
+├── Flows/
+│   ├── Shared/
+│   │   └── TransactionCleaning.cs
+│   ├── EagerIngest/
+│   │   └── Steps/
+│   │       └── NormalizeTransactionsStep.cs
+│   ├── StreamingIngest/
+│   │   └── Steps/
+│   │       └── CleanTransactionStreamView.cs
+│   └── Reporting/
+│       └── Steps/
+│           ├── RenderMemoryReportStep.cs
+│           └── SummarizeMemoryStep.cs
+└── scripts/
+    └── generate-dataset.sh
+```
+<!-- flowthru:filetree:end -->

--- a/examples/advanced/StreamingBulkLoad/StreamingBulkLoad.csproj
+++ b/examples/advanced/StreamingBulkLoad/StreamingBulkLoad.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateProgramFile>false</GenerateProgramFile>
+
+    <!-- Workstation, non-concurrent GC so the working-set sampler tracks
+         allocation closely rather than server-GC's pre-reserved heaps —
+         the memory contrast is the whole point of this example. -->
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src/core/Flowthru.Core/Flowthru.Core.csproj" />
+    <ProjectReference Include="$(RepoRoot)src/extensions/Flowthru.Extensions.Csv/Flowthru.Extensions.Csv.csproj" />
+    <ProjectReference Include="$(RepoRoot)src/extensions/Flowthru.Extensions.Parquet/Flowthru.Extensions.Parquet.csproj" />
+    <ProjectReference Include="$(RepoRoot)src/extensions/Flowthru.Extensions.EFCore/Flowthru.Extensions.EFCore.csproj" />
+    <ProjectReference Include="$(RepoRoot)src/extensions/Flowthru.Extensions.EFCore.Bulk/Flowthru.Extensions.EFCore.Bulk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src/core/Flowthru.Core.SourceGenerators/Flowthru.Core.SourceGenerators.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer" />
+  </ItemGroup>
+
+</Project>

--- a/examples/advanced/StreamingBulkLoad/project.json
+++ b/examples/advanced/StreamingBulkLoad/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "StreamingBulkLoad",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "examples/advanced/StreamingBulkLoad",
+  "tags": [ "scope:examples", "scope:advanced" ],
+  "targets": {
+    "generate": {
+      "//": "Regenerate the synthetic multi-row-group Parquet dataset. Row count via --rows or the STREAMINGBULKLOAD_ROWS env var.",
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [ "dotnet run -- --generate" ],
+        "cwd": "examples/advanced/StreamingBulkLoad",
+        "parallel": false
+      }
+    },
+    "run": {
+      "//": "Generate the dataset if missing, measure eager vs streaming ingest into SQLite, and render memory_report.md.",
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [ "dotnet run" ],
+        "cwd": "examples/advanced/StreamingBulkLoad",
+        "parallel": false
+      }
+    }
+  }
+}

--- a/examples/advanced/StreamingBulkLoad/scripts/generate-dataset.sh
+++ b/examples/advanced/StreamingBulkLoad/scripts/generate-dataset.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Regenerate the synthetic multi-row-group Parquet dataset this example reads.
+#
+# Row count knob (larger = wider eager-vs-streaming memory gap, longer runtime):
+#   ./scripts/generate-dataset.sh              # default (200,000 rows)
+#   ./scripts/generate-dataset.sh 2000000      # crank it up to 2,000,000
+#   STREAMINGBULKLOAD_ROWS=500000 ./scripts/generate-dataset.sh
+#
+# The dataset lands at Data/_01_Raw/Datasets/transactions.parquet with small
+# (10,000-row) row groups so even a modest dataset spans many groups — that is
+# what lets the streaming reader keep peak memory to one row group.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+ROWS="${1:-${STREAMINGBULKLOAD_ROWS:-}}"
+
+cd "$PROJECT_DIR"
+if [[ -n "$ROWS" ]]; then
+  dotnet run -- --generate --rows "$ROWS"
+else
+  dotnet run -- --generate
+fi

--- a/src/core/Flowthru.Core.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/core/Flowthru.Core.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -12,6 +12,7 @@
 | FT1004  | Flowthru.Schema     | Error    | FlowthruColumn properties have inconsistent backing types          |
 | FT1101  | Flowthru.Step       | Warning  | Step factory class missing [FlowthruStep] attribute                |
 | FT1102  | Flowthru.Step       | Error    | Read-only catalog item used as step output                         |
+| FT1201  | Flowthru.Storage    | Error    | Format declares CanStream but does not stream                      |
 | FT1301  | Flowthru.Step       | Error    | Step extension misses minimum container support                    |
 | FT1303  | Flowthru.Step       | Error    | Step extension capability/marshaller mismatch                      |
 | FT2001  | Flowthru.Validation | Error    | Single-producer invariant violated                                 |

--- a/src/core/Flowthru.Core.SourceGenerators/Step/ExtensionCapabilityMarshallerAlignmentAnalyzer.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/Step/ExtensionCapabilityMarshallerAlignmentAnalyzer.cs
@@ -26,13 +26,11 @@ public sealed class ExtensionCapabilityMarshallerAlignmentAnalyzer : DiagnosticA
   internal const string CapabilitiesAttributeFullName = "Flowthru.Step.StepExtensionCapabilitiesAttribute";
   internal const string ContainerMarshallerOpenName = "Flowthru.Step.Marshalling.IContainerMarshaller<TExtension>";
   internal const string QueryableMarshallerOpenName = "Flowthru.Step.Marshalling.IQueryableMarshaller<TExtension>";
-  internal const string AsyncStreamMarshallerOpenName = "Flowthru.Step.Marshalling.IAsyncStreamMarshaller<TExtension>";
 
   // Mirrors StepContainerKind bit layout.
   private const int Singleton = 1;
   private const int Enumerable = 1 << 1;
   private const int Queryable = 1 << 2;
-  private const int AsyncStream = 1 << 3;
   private const int FloorBits = Singleton | Enumerable;
 
   /// <inheritdoc/>
@@ -62,7 +60,6 @@ public sealed class ExtensionCapabilityMarshallerAlignmentAnalyzer : DiagnosticA
     var declared = inputs | outputs;
     var hasContainer = ImplementsOpenGenericInterface(type, ContainerMarshallerOpenName);
     var hasQueryable = ImplementsOpenGenericInterface(type, QueryableMarshallerOpenName);
-    var hasAsyncStream = ImplementsOpenGenericInterface(type, AsyncStreamMarshallerOpenName);
 
     var location = capabilitiesAttr.ApplicationSyntaxReference?
       .GetSyntax(context.CancellationToken).GetLocation() ?? type.Locations.FirstOrDefault();
@@ -101,22 +98,10 @@ public sealed class ExtensionCapabilityMarshallerAlignmentAnalyzer : DiagnosticA
         + "Add Queryable to the attribute's Inputs or Outputs, or remove the marker interface.");
     }
 
-    // ── Opt-in: AsyncStream. ──
-    var declaresAsyncStream = (declared & AsyncStream) != 0;
-    if (declaresAsyncStream && !hasAsyncStream)
-    {
-      Report(context, location, type.Name,
-        "declares AsyncStream container support but does not implement "
-        + "Flowthru.Step.Marshalling.IAsyncStreamMarshaller<" + type.Name + ">. "
-        + "Add the marker interface, or remove AsyncStream from the attribute.");
-    }
-    else if (!declaresAsyncStream && hasAsyncStream)
-    {
-      Report(context, location, type.Name,
-        "implements Flowthru.Step.Marshalling.IAsyncStreamMarshaller<" + type.Name + "> but the "
-        + "[StepExtensionCapabilities] attribute does not declare AsyncStream. "
-        + "Add AsyncStream to the attribute's Inputs or Outputs, or remove the marker interface.");
-    }
+    // Note: StepContainerKind.Source (a FlowSource<T> streaming payload) has
+    // no marshaller marker — per ADR-0023 a FlowSource is consumed by
+    // compiling back into FlowIO, not marshalled across a marker seam — so
+    // there is no alignment check for it here.
   }
 
   private static void Report(

--- a/src/core/Flowthru.Core.SourceGenerators/Step/ExtensionMinimumContainerSupportAnalyzer.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/Step/ExtensionMinimumContainerSupportAnalyzer.cs
@@ -143,7 +143,7 @@ public sealed class ExtensionMinimumContainerSupportAnalyzer : DiagnosticAnalyze
     if ((bits & Singleton) != 0) parts.Add("Singleton");
     if ((bits & Enumerable) != 0) parts.Add("Enumerable");
     if ((bits & (1 << 2)) != 0) parts.Add("Queryable");
-    if ((bits & (1 << 3)) != 0) parts.Add("AsyncStream");
+    if ((bits & (1 << 3)) != 0) parts.Add("Source");
 
     return parts.Count == 0 ? $"0x{bits:X}" : string.Join(" | ", parts);
   }

--- a/src/core/Flowthru.Core.SourceGenerators/Step/StepDiagnostics.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/Step/StepDiagnostics.cs
@@ -103,7 +103,7 @@ public static class StepDiagnostics
       defaultSeverity: DiagnosticSeverity.Error,
       isEnabledByDefault: true,
       description: "The [StepExtensionCapabilities] attribute and the IContainerMarshaller / "
-        + "IQueryableMarshaller / IAsyncStreamMarshaller marker interfaces are two halves of the same "
+        + "IQueryableMarshaller marker interfaces are two halves of the same "
         + "contract — capability disclosure and implementation evidence. They must agree. "
         + "An attribute declaring a kind without the matching marker interface (or a marker interface "
         + "implemented without the matching kind declared) is silent drift that breaks at runtime."

--- a/src/core/Flowthru.Core.SourceGenerators/Storage/StorageDiagnostics.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/Storage/StorageDiagnostics.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+
+namespace Flowthru.Core.SourceGenerators.Storage;
+
+/// <summary>
+/// Diagnostic descriptors for storage-format capability analyzers. Lives in
+/// the <c>FT12xx</c> block of the <c>FT1xxx</c> capability-shape range —
+/// structural correctness of a format serializer's declared capabilities —
+/// parallel to <see cref="Step.StepDiagnostics"/> (step-extension shape) and
+/// <see cref="Schema.SchemaGeneratorDiagnostics"/> (schema shape).
+/// </summary>
+public static class StorageDiagnostics
+{
+  private const string Category = "Flowthru.Storage";
+
+  /// <summary>
+  /// FT1201: a format serializer declares <c>StorageTraits.CanStream = true</c>
+  /// but does not actually stream — either it omits the structural
+  /// <c>IFormatStreamReader&lt;TRow&gt;</c> marker, or its
+  /// <c>DeserializeRows</c> body materialises the whole input (a whole-document
+  /// <c>JsonSerializer.Deserialize</c>/<c>DeserializeAsync</c> call, or a
+  /// <c>ToList</c>/<c>ToListAsync</c>/<c>ToArray</c>/<c>ToArrayAsync</c> over the
+  /// input stream) before yielding. The <c>CanStream</c> trait promises O(batch)
+  /// memory; a materialising body breaks that promise silently.
+  /// </summary>
+  public static readonly DiagnosticDescriptor StreamingTraitDishonest =
+    new(
+      id: "FT1201",
+      title: "Format declares CanStream but does not stream",
+      messageFormat: "Format serializer '{0}': {1}",
+      category: Category,
+      defaultSeverity: DiagnosticSeverity.Error,
+      isEnabledByDefault: true,
+      description: "StorageTraits.CanStream = true is a promise that DeserializeRows yields rows "
+        + "incrementally in bounded (O(batch)) memory. The runtime trait/marker drift law "
+        + "(IFormatSerializerLaws.TraitsAgreeWithMarkerInterfacesLaw) checks the CanStream flag against "
+        + "the IFormatStreamReader<TRow> marker at test time; this analyzer adds the compile-time signal "
+        + "the drift law cannot give — a DeserializeRows body that materialises the whole input while "
+        + "declaring CanStream = true. Either make the read genuinely streaming, or set CanStream = false "
+        + "and implement only IFormatRowReader<TRow>."
+    );
+}

--- a/src/core/Flowthru.Core.SourceGenerators/Storage/StreamingTraitHonestyAnalyzer.cs
+++ b/src/core/Flowthru.Core.SourceGenerators/Storage/StreamingTraitHonestyAnalyzer.cs
@@ -1,0 +1,202 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Flowthru.Core.SourceGenerators.Storage;
+
+/// <summary>
+/// Analyzer that emits <c>FT1201</c> when a format serializer declares
+/// <c>StorageTraits.CanStream = true</c> but does not actually stream.
+/// </summary>
+/// <remarks>
+/// <para>Two sub-cases, one diagnostic:</para>
+/// <list type="number">
+///   <item><description><b>Marker honesty</b> — <c>CanStream = true</c> without
+///     implementing <c>Flowthru.Data.Storage.IFormatStreamReader&lt;TRow&gt;</c>.
+///     This is the compile-time complement of the runtime drift law in
+///     <c>IFormatSerializerLaws</c> (which only fires once a laws test is
+///     written).</description></item>
+///   <item><description><b>Body honesty</b> — <c>CanStream = true</c> with a
+///     <c>DeserializeRows</c> body that materialises the whole input: a
+///     whole-document <c>JsonSerializer.Deserialize</c>/<c>DeserializeAsync</c>
+///     call, or a <c>ToList</c>/<c>ToListAsync</c>/<c>ToArray</c>/<c>ToArrayAsync</c>
+///     applied to the input <c>stream</c>. This is the signal the runtime drift
+///     law cannot give — it inspects only the flag/marker agreement, never the
+///     body.</description></item>
+/// </list>
+/// <para>
+/// Deliberately conservative to keep false positives near zero: the body check
+/// flags a materialisation only when its receiver names the <c>stream</c>
+/// parameter (so a bounded per-row-group <c>ToList</c> over decoded metadata —
+/// as in the Parquet reader — is not flagged), and matches only the
+/// whole-document JSON entry points (never <c>DeserializeAsyncEnumerable</c>).
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StreamingTraitHonestyAnalyzer : DiagnosticAnalyzer
+{
+  internal const string FormatRowReaderOpenName = "Flowthru.Data.Storage.IFormatRowReader<TRow>";
+  internal const string FormatStreamReaderOpenName = "Flowthru.Data.Storage.IFormatStreamReader<TRow>";
+
+  private static readonly ImmutableHashSet<string> MaterializingCalls =
+    ImmutableHashSet.Create("ToList", "ToListAsync", "ToArray", "ToArrayAsync");
+
+  /// <inheritdoc/>
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+    ImmutableArray.Create(StorageDiagnostics.StreamingTraitDishonest);
+
+  /// <inheritdoc/>
+  public override void Initialize(AnalysisContext context)
+  {
+    context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+    context.EnableConcurrentExecution();
+    context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+  }
+
+  private static void AnalyzeNamedType(SymbolAnalysisContext context)
+  {
+    var type = (INamedTypeSymbol)context.Symbol;
+    if (type.TypeKind != TypeKind.Class) return;
+
+    // Gate: only format serializers (IFormatRowReader<TRow> implementers).
+    // This excludes storage adapters / media that carry CanStream on their own
+    // traits (EFCore, S3, HTTP) — those are not format-serializer read paths.
+    if (!ImplementsOpenGenericInterface(type, FormatRowReaderOpenName)) return;
+
+    // Only act when the type declares CanStream = true on its own Traits member.
+    if (!TryFindCanStreamTrue(type, context.CancellationToken, out var canStreamLocation)) return;
+
+    // ── Branch 1: marker honesty (compile-time complement of the drift law). ──
+    if (!ImplementsOpenGenericInterface(type, FormatStreamReaderOpenName))
+    {
+      Report(context, canStreamLocation, type.Name,
+        "declares StorageTraits.CanStream = true but does not implement "
+        + "Flowthru.Data.Storage.IFormatStreamReader<TRow>. A genuinely streaming format carries the "
+        + "IFormatStreamReader<TRow> marker; add it, or set CanStream = false.");
+    }
+
+    // ── Branch 2: body honesty (the signal the drift law cannot give). ──
+    foreach (var (location, detail) in FindWholeInputMaterializations(type, context.CancellationToken))
+    {
+      Report(context, location, type.Name, detail);
+    }
+  }
+
+  /// <summary>
+  /// Finds an object-initializer assignment <c>CanStream = true</c> on the
+  /// type's own <c>Traits</c> member (property or field). Returns its location
+  /// so branch-1 diagnostics point at the offending trait declaration.
+  /// </summary>
+  private static bool TryFindCanStreamTrue(
+    INamedTypeSymbol type,
+    CancellationToken ct,
+    out Location location)
+  {
+    location = type.Locations.FirstOrDefault() ?? Location.None;
+
+    foreach (var member in type.GetMembers("Traits"))
+    {
+      if (member is not (IPropertySymbol or IFieldSymbol)) continue;
+
+      foreach (var syntaxRef in member.DeclaringSyntaxReferences)
+      {
+        var assignment = syntaxRef.GetSyntax(ct)
+          .DescendantNodes()
+          .OfType<AssignmentExpressionSyntax>()
+          .FirstOrDefault(IsCanStreamTrue);
+        if (assignment is not null)
+        {
+          location = assignment.GetLocation();
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private static bool IsCanStreamTrue(AssignmentExpressionSyntax assignment) =>
+    assignment.Left is IdentifierNameSyntax { Identifier.ValueText: "CanStream" }
+    && assignment.Right is LiteralExpressionSyntax literal
+    && literal.IsKind(SyntaxKind.TrueLiteralExpression);
+
+  /// <summary>
+  /// Scans the type's <c>DeserializeRows</c> method bodies for calls that
+  /// materialise the whole input, yielding one (location, detail) per offence.
+  /// </summary>
+  private static IEnumerable<(Location Location, string Detail)> FindWholeInputMaterializations(
+    INamedTypeSymbol type,
+    CancellationToken ct)
+  {
+    foreach (var member in type.GetMembers("DeserializeRows").OfType<IMethodSymbol>())
+    {
+      foreach (var syntaxRef in member.DeclaringSyntaxReferences)
+      {
+        if (syntaxRef.GetSyntax(ct) is not MethodDeclarationSyntax method) continue;
+
+        var streamParam = method.ParameterList.Parameters.FirstOrDefault()?.Identifier.ValueText;
+
+        foreach (var invocation in method.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+          var detail = ClassifyInvocation(invocation, streamParam);
+          if (detail is not null)
+          {
+            yield return (invocation.GetLocation(), detail);
+          }
+        }
+      }
+    }
+  }
+
+  private static string? ClassifyInvocation(InvocationExpressionSyntax invocation, string? streamParam)
+  {
+    if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return null;
+    var calledName = memberAccess.Name.Identifier.ValueText;
+
+    // Whole-document JSON deserialize (deliberately not DeserializeAsyncEnumerable).
+    if ((calledName == "Deserialize" || calledName == "DeserializeAsync")
+        && ReceiverTrailingNameEquals(memberAccess.Expression, "JsonSerializer"))
+    {
+      return "its DeserializeRows body calls the whole-document JsonSerializer." + calledName
+        + "(...) rather than the streaming JsonSerializer.DeserializeAsyncEnumerable(...) API, which "
+        + "buffers the entire input before yielding. Use the streaming API, or set CanStream = false.";
+    }
+
+    // Materialising the input stream (ToList/ToArray over something derived from `stream`).
+    if (MaterializingCalls.Contains(calledName)
+        && streamParam is not null
+        && ReceiverReferencesIdentifier(memberAccess.Expression, streamParam))
+    {
+      return "its DeserializeRows body calls ." + calledName + "() over the input stream, materialising "
+        + "the whole dataset before yielding — O(dataset) memory, not the O(batch) that CanStream = true "
+        + "promises. Yield incrementally, or set CanStream = false.";
+    }
+
+    return null;
+  }
+
+  private static bool ReceiverReferencesIdentifier(ExpressionSyntax receiver, string name) =>
+    receiver.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>()
+      .Any(id => id.Identifier.ValueText == name);
+
+  private static bool ReceiverTrailingNameEquals(ExpressionSyntax receiver, string name) =>
+    receiver switch
+    {
+      IdentifierNameSyntax id => id.Identifier.ValueText == name,
+      MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText == name,
+      _ => false,
+    };
+
+  private static void Report(SymbolAnalysisContext context, Location location, string typeName, string detail) =>
+    context.ReportDiagnostic(Diagnostic.Create(
+      StorageDiagnostics.StreamingTraitDishonest, location, typeName, detail));
+
+  private static bool ImplementsOpenGenericInterface(INamedTypeSymbol type, string openGenericFullName) =>
+    type.AllInterfaces.Any(i =>
+      i.IsGenericType && i.OriginalDefinition.ToDisplayString() == openGenericFullName);
+}

--- a/src/core/Flowthru.Core/Data/Catalog/CatalogItemExtensions.cs
+++ b/src/core/Flowthru.Core/Data/Catalog/CatalogItemExtensions.cs
@@ -79,6 +79,46 @@ public static class CatalogItemExtensions
   }
 
   /// <summary>
+  /// Derive a read-only <em>streaming</em> view of a collection item:
+  /// <c>IItem&lt;IEnumerable&lt;TRow&gt;&gt;</c> →
+  /// <c>IReadOnlyItem&lt;FlowSource&lt;TRow&gt;&gt;</c>. The view's
+  /// <c>Load()</c> yields a deferred <see cref="Prelude.FlowSource{TRow}"/>
+  /// whose peak read memory is O(batch), not O(file).
+  /// </summary>
+  /// <remarks>
+  /// Read-only because composed streaming <em>writes</em> are out of scope
+  /// (ADR-0023). Gated to streaming-capable composed formats: calling this on a
+  /// direct adapter (EFCore, Sheets, GQL) or a non-streaming format throws at
+  /// wire-up — a design-time error, never a silent O(file) materialise. A
+  /// <c>.Constrain()</c> wrapper is unwrapped to reach the composed format.
+  /// </remarks>
+  public static IReadOnlyItem<FlowSource<TRow>> AsStream<TRow>(this IItem<IEnumerable<TRow>> item)
+    where TRow : notnull
+  {
+    if (item is null) throw new ArgumentNullException(nameof(item));
+
+    var adapter = ResolveStorageAdapter(item);
+    if (adapter is ConstrainedStorageAdapter<IEnumerable<TRow>> constrained)
+    {
+      adapter = constrained.Inner;
+    }
+
+    if (adapter is not ISupportsStreamingView<TRow> streamable || !streamable.SupportsStreaming)
+    {
+      throw new ArgumentException(
+        $"AsStream() requires item '{item.Label}' to be backed by a streaming-capable composed "
+        + $"format (an IFormatStreamReader<{typeof(TRow).Name}>). Its adapter "
+        + $"({adapter?.GetType().Name ?? "none"}) does not support streaming reads — direct "
+        + "adapters (EFCore, Sheets, GQL) and non-streaming formats cannot stream. Use the "
+        + "eager item, or a streaming-capable format.",
+        nameof(item)
+      );
+    }
+
+    return new StreamingItem<TRow>(item.Label, streamable, item);
+  }
+
+  /// <summary>
   /// Best-effort extraction of the underlying <see cref="IStorageAdapter{T}"/>
   /// from a catalog item. Recognises <see cref="Item{T}"/> directly and
   /// <see cref="ConstrainedStorageAdapter{T}"/>-wrapped items; falls back to

--- a/src/core/Flowthru.Core/Data/Catalog/FlowSinkItem.cs
+++ b/src/core/Flowthru.Core/Data/Catalog/FlowSinkItem.cs
@@ -1,0 +1,47 @@
+using Flowthru.Data.Storage;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Data.Catalog;
+
+/// <summary>
+/// A write-only DAG output that compiles a streamed <see cref="FlowSource{T}"/>
+/// into an <see cref="IFlowSink{T}"/>. Created by
+/// <c>FlowBuilder.AddBulkLoad(...)</c> as the output of a streaming bulk-load
+/// step: <see cref="Save"/> drives the batch sink (O(batch) memory);
+/// <see cref="Load"/> fails, because a sink is not a readable source.
+/// </summary>
+/// <typeparam name="T">The row type written to the sink.</typeparam>
+internal sealed class FlowSinkItem<T> : IItem<FlowSource<T>>
+  where T : notnull
+{
+  private readonly IFlowSink<T> _sink;
+
+  internal FlowSinkItem(string label, IFlowSink<T> sink)
+  {
+    Label = label ?? throw new ArgumentNullException(nameof(label));
+    _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+  }
+
+  public string Label { get; }
+  public NodeTraits Traits => new();
+  public Type DataType => typeof(FlowSource<T>);
+
+  public FlowIO<FlowSource<T>> Load() =>
+    FlowIO.Fail<FlowSource<T>>(new RuntimeError.External(
+      $"FlowSinkItem[{Label}].Load",
+      new InvalidOperationException(
+        $"Bulk-load sink '{Label}' is write-only — it consumes a FlowSource and cannot be loaded from.")));
+
+  public FlowIO<FlowUnit> Save(FlowSource<T> data) => data.Compile().Into(_sink);
+
+  // A sink has no pre-existing readable state; the write target is reachable.
+  public FlowIO<bool> Exists() => FlowIO.Pure(false);
+  public FlowIO<ValidationResult> InspectShallow(int sampleSize = 100) => FlowIO.Pure(ValidationResult.Success());
+  public FlowIO<ValidationResult> InspectDeep() => FlowIO.Pure(ValidationResult.Success());
+  public FlowIO<ValidationResult> InspectTarget() => FlowIO.Pure(ValidationResult.Success());
+  public FlowIO<ValidationResult> Validate() => FlowIO.Pure(ValidationResult.Success());
+
+  public FlowIO<object> LoadUntyped() => Load().Map(value => (object)value!);
+  public FlowIO<FlowUnit> SaveUntyped(object data) => Save((FlowSource<T>)data);
+}

--- a/src/core/Flowthru.Core/Data/Catalog/Item.Introspection.cs
+++ b/src/core/Flowthru.Core/Data/Catalog/Item.Introspection.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Flowthru.Prelude;
 using Flowthru.Step;
 
 namespace Flowthru.Data.Catalog;
@@ -19,7 +20,7 @@ namespace Flowthru.Data.Catalog;
 /// repo ask for the surface we can promote without API churn.
 /// </para>
 /// <para>
-/// Resolution order: <see cref="StepContainerKind.AsyncStream"/> →
+/// Resolution order: <see cref="StepContainerKind.Source"/> →
 /// <see cref="StepContainerKind.Queryable"/> →
 /// <see cref="StepContainerKind.Enumerable"/> →
 /// <see cref="StepContainerKind.Singleton"/>, with two special cases
@@ -48,12 +49,17 @@ public static partial class Item
     if (type == typeof(string)) return StepContainerKind.Singleton;
     if (type.IsArray) return StepContainerKind.Singleton;
 
+    // FlowSource<T> is the streaming catalog payload (the .AsStream()
+    // view). It is a sealed class implementing none of the sequence
+    // interfaces, so without this structural case it falls through to
+    // Singleton with row type FlowSource<T> — the exact
+    // misclassification ADR-0023 corrects.
+    if (ImplementsOpenGeneric(type, typeof(FlowSource<>)))
+      return StepContainerKind.Source;
+
     // Walk in specificity order — IQueryable<T> implements
     // IEnumerable<T>, so we test it first to pick the more-specific
     // tag.
-    if (ImplementsOpenGeneric(type, typeof(IAsyncEnumerable<>)))
-      return StepContainerKind.AsyncStream;
-
     if (ImplementsOpenGeneric(type, typeof(System.Linq.IQueryable<>)))
       return StepContainerKind.Queryable;
 
@@ -82,10 +88,10 @@ public static partial class Item
 
   /// <summary>
   /// View function: the underlying row type of <paramref name="type"/>.
-  /// For containers (<c>IEnumerable&lt;TRow&gt;</c>,
-  /// <c>IQueryable&lt;TRow&gt;</c>,
-  /// <c>IAsyncEnumerable&lt;TRow&gt;</c>) returns the element type;
-  /// for singletons returns <paramref name="type"/> itself.
+  /// For containers (<c>Flowthru.Prelude.FlowSource&lt;TRow&gt;</c>,
+  /// <c>IEnumerable&lt;TRow&gt;</c>, <c>IQueryable&lt;TRow&gt;</c>)
+  /// returns the element type; for singletons returns
+  /// <paramref name="type"/> itself.
   /// </summary>
   internal static Type RowTypeOf(Type type)
   {
@@ -95,8 +101,8 @@ public static partial class Item
     if (type == typeof(string)) return type;
     if (type.IsArray) return type;
 
-    var asyncStream = FindClosedGeneric(type, typeof(IAsyncEnumerable<>));
-    if (asyncStream is not null) return asyncStream.GetGenericArguments()[0];
+    var source = FindClosedGeneric(type, typeof(FlowSource<>));
+    if (source is not null) return source.GetGenericArguments()[0];
 
     var queryable = FindClosedGeneric(type, typeof(System.Linq.IQueryable<>));
     if (queryable is not null) return queryable.GetGenericArguments()[0];

--- a/src/core/Flowthru.Core/Data/Catalog/StreamingItem.cs
+++ b/src/core/Flowthru.Core/Data/Catalog/StreamingItem.cs
@@ -1,0 +1,56 @@
+using Flowthru.Data.Storage;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Data.Catalog;
+
+/// <summary>
+/// A read-only catalog item whose payload is a deferred
+/// <see cref="FlowSource{TRow}"/> stream — the view produced by
+/// <c>IItem&lt;IEnumerable&lt;TRow&gt;&gt;.AsStream()</c>. <see cref="Load"/>
+/// hands back the (lazy) source description; nothing is read until a consumer
+/// compiles and runs it. Node-level concerns (existence, inspection,
+/// fingerprint, gating) delegate to the eager origin item, since both are
+/// backed by the same medium.
+/// </summary>
+/// <typeparam name="TRow">The row type produced by the stream.</typeparam>
+internal sealed class StreamingItem<TRow> : IReadOnlyItem<FlowSource<TRow>>
+  where TRow : notnull
+{
+  private readonly ISupportsStreamingView<TRow> _source;
+  private readonly IItem _origin;
+
+  internal StreamingItem(string label, ISupportsStreamingView<TRow> source, IItem origin)
+  {
+    Label = label ?? throw new ArgumentNullException(nameof(label));
+    _source = source ?? throw new ArgumentNullException(nameof(source));
+    _origin = origin ?? throw new ArgumentNullException(nameof(origin));
+  }
+
+  public string Label { get; }
+  public NodeTraits Traits => _origin.Traits;
+  public Type DataType => typeof(FlowSource<TRow>);
+  public InspectionLevel? MaxInspectionLevel => _origin.MaxInspectionLevel;
+  public bool HasEfficientCount => _origin.HasEfficientCount;
+  public string? StorageKind => _origin.StorageKind;
+
+  public FlowIO<FlowSource<TRow>> Load() => FlowIO.Pure(_source.OpenStreamingSource());
+
+  public FlowIO<FlowUnit> Save(FlowSource<TRow> data) =>
+    FlowIO.Fail<FlowUnit>(new RuntimeError.External(
+      $"StreamingItem[{Label}].Save",
+      new InvalidOperationException(
+        $"Streaming item '{Label}' is read-only — .AsStream() produces an input-only view. "
+        + "Write through the eager item instead.")));
+
+  public FlowIO<bool> Exists() => _origin.Exists();
+  public FlowIO<ValidationResult> InspectShallow(int sampleSize = 100) => _origin.InspectShallow(sampleSize);
+  public FlowIO<ValidationResult> InspectDeep() => _origin.InspectDeep();
+  public FlowIO<ValidationResult> InspectTarget() => _origin.InspectTarget();
+  public FlowIO<ValidationResult> Validate() => _origin.InspectShallow();
+
+  public FlowIO<object> LoadUntyped() => Load().Map(value => (object)value!);
+  public FlowIO<FlowUnit> SaveUntyped(object data) => Save((FlowSource<TRow>)data);
+
+  public FlowIO<string>? TryGetFingerprint() => _origin.TryGetFingerprint();
+}

--- a/src/core/Flowthru.Core/Data/Storage/ComposedStorageAdapter.cs
+++ b/src/core/Flowthru.Core/Data/Storage/ComposedStorageAdapter.cs
@@ -107,7 +107,7 @@ public sealed class ComposedStorageAdapter<TContainer, TRow>
       {
         try
         {
-          var rows = _reader.DeserializeRows(stream);
+          var rows = _reader.DeserializeRows(stream, ct);
           return await _container.FromRows(rows).ConfigureAwait(false);
         }
         finally
@@ -250,7 +250,7 @@ public sealed class ComposedStorageAdapter<TContainer, TRow>
     var stream = ((EffResult<Stream>.Success)streamResult).Value;
     try
     {
-      var rows = _reader.DeserializeRows(stream);
+      var rows = _reader.DeserializeRows(stream, ct);
       var count = 0;
       await foreach (var _ in rows.WithCancellation(ct).ConfigureAwait(false))
       {

--- a/src/core/Flowthru.Core/Data/Storage/ComposedStorageAdapter.cs
+++ b/src/core/Flowthru.Core/Data/Storage/ComposedStorageAdapter.cs
@@ -20,7 +20,7 @@ namespace Flowthru.Data.Storage;
 /// </para>
 /// </remarks>
 public sealed class ComposedStorageAdapter<TContainer, TRow>
-  : IStorageAdapter<TContainer>, ISupportsFingerprint, IHasServiceDependencies
+  : IStorageAdapter<TContainer>, ISupportsFingerprint, IHasServiceDependencies, ISupportsStreamingView<TRow>
   where TRow : notnull
 {
   private readonly IStorageMedium _medium;
@@ -133,6 +133,39 @@ public sealed class ComposedStorageAdapter<TContainer, TRow>
           InnerExceptionInfo: smx.InnerException?.ToString()
         )
       : error;
+
+  // ── ISupportsStreamingView<TRow> (the .AsStream() seam) ────────────────
+
+  /// <inheritdoc/>
+  public bool SupportsStreaming => _reader is IFormatStreamReader<TRow>;
+
+  /// <inheritdoc/>
+  public FlowSource<TRow> OpenStreamingSource()
+  {
+    if (_reader is not IFormatStreamReader<TRow>)
+    {
+      throw new InvalidOperationException(
+        $"Format '{_reader.GetType().Name}' does not support streaming reads for "
+        + $"'{typeof(TRow).Name}' (it is not an IFormatStreamReader<{typeof(TRow).Name}>). "
+        + "Use the eager Load() path, or bind a streaming-capable format."
+      );
+    }
+
+    // Deferred: the medium stream is acquired on the first pull inside the
+    // FlowSource bracket and disposed on every exit path (completion, failure,
+    // cancellation, early break). The reader throws SchemaMismatchException from
+    // inside the row stream; TranslateSchemaMismatch lifts that External wrapper
+    // to the typed RuntimeError.SchemaMismatch at the compile boundary — the
+    // storage layer is where SchemaMismatchException is visible, not the Prelude.
+    var reader = _reader;
+    var resource = FlowResource.Make<Stream>(
+      acquire: _medium.ReadStream(),
+      release: (stream, _) => FlowIO.Lift(() => { stream.Dispose(); return FlowUnit.Default; })
+    );
+    return FlowSource
+      .Bracket(resource, (stream, ct) => reader.DeserializeRows(stream, ct))
+      .MapError(TranslateSchemaMismatch);
+  }
 
   /// <inheritdoc/>
   public FlowIO<FlowUnit> Save(TContainer data)

--- a/src/core/Flowthru.Core/Data/Storage/IFormatRowReader.cs
+++ b/src/core/Flowthru.Core/Data/Storage/IFormatRowReader.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Flowthru.Data.Storage;
 
 /// <summary>
@@ -16,5 +18,8 @@ public interface IFormatRowReader<TRow> : IFormatBase<TRow>
   /// as deserialized (lazy enumeration) so consumers can process large
   /// datasets without materializing everything in memory.
   /// </summary>
-  IAsyncEnumerable<TRow> DeserializeRows(Stream stream);
+  IAsyncEnumerable<TRow> DeserializeRows(
+    Stream stream,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default
+  );
 }

--- a/src/core/Flowthru.Core/Data/Storage/IFormatStreamReader.cs
+++ b/src/core/Flowthru.Core/Data/Storage/IFormatStreamReader.cs
@@ -9,11 +9,11 @@ namespace Flowthru.Data.Storage;
 /// </summary>
 /// <typeparam name="TRow">The row type produced by deserialization.</typeparam>
 /// <remarks>
-/// Formats that buffer the full payload (JSON-as-array via
-/// <c>JsonSerializer.Deserialize</c>) implement only the parent
-/// <see cref="IFormatRowReader{TRow}"/>. Formats that decode row-at-a-time
-/// off a forward-only cursor (CsvHelper, Parquet's row-group iteration)
-/// implement this segment.
+/// Formats that buffer the full payload before yielding implement only the
+/// parent <see cref="IFormatRowReader{TRow}"/>. Formats that decode
+/// row-at-a-time off a forward-only cursor — CsvHelper, Parquet's row-group
+/// iteration, JSON via <c>DeserializeAsyncEnumerable</c> — implement this
+/// segment.
 /// </remarks>
 public interface IFormatStreamReader<TRow> : IFormatRowReader<TRow>
   where TRow : notnull

--- a/src/core/Flowthru.Core/Data/Storage/ISupportsStreamingView.cs
+++ b/src/core/Flowthru.Core/Data/Storage/ISupportsStreamingView.cs
@@ -1,0 +1,34 @@
+using Flowthru.Prelude;
+
+namespace Flowthru.Data.Storage;
+
+/// <summary>
+/// Capability seam for the streaming catalog view: a composed storage adapter
+/// whose format can stream can hand out a deferred <see cref="FlowSource{TRow}"/>
+/// over its rows — the source that
+/// <c>IItem&lt;IEnumerable&lt;TRow&gt;&gt;.AsStream()</c> wraps. The underlying
+/// byte source is acquired on the first pull and released on every exit path.
+/// </summary>
+/// <remarks>
+/// Only formats that genuinely stream (implement
+/// <see cref="IFormatStreamReader{TRow}"/>) can produce a streaming view;
+/// <see cref="SupportsStreaming"/> lets <c>AsStream()</c> reject non-streaming
+/// formats and direct adapters (EFCore, Sheets, GQL) at wire-up rather than
+/// silently materialising.
+/// </remarks>
+/// <typeparam name="TRow">The row type produced by the stream.</typeparam>
+public interface ISupportsStreamingView<TRow>
+  where TRow : notnull
+{
+  /// <summary>
+  /// True when the underlying format supports streaming reads. When false,
+  /// <see cref="OpenStreamingSource"/> throws.
+  /// </summary>
+  bool SupportsStreaming { get; }
+
+  /// <summary>
+  /// Build a deferred <see cref="FlowSource{TRow}"/> over this adapter's medium
+  /// and reader. Nothing is opened until the source is compiled and run.
+  /// </summary>
+  FlowSource<TRow> OpenStreamingSource();
+}

--- a/src/core/Flowthru.Core/Data/Storage/JsonFormatSerializer.cs
+++ b/src/core/Flowthru.Core/Data/Storage/JsonFormatSerializer.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Flowthru.Data.Schema;
@@ -63,14 +64,18 @@ public sealed class JsonFormatSerializer<TRow>
   public StorageTraits Traits => new() { CanStream = false };
 
   /// <inheritdoc/>
-  public async IAsyncEnumerable<TRow> DeserializeRows(Stream stream)
+  public async IAsyncEnumerable<TRow> DeserializeRows(
+    Stream stream,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     if (stream is null)
     {
       throw new ArgumentNullException(nameof(stream));
     }
 
-    await foreach (var item in JsonSerializer.DeserializeAsyncEnumerable<TRow>(stream, _options).ConfigureAwait(false))
+    await foreach (var item in JsonSerializer
+      .DeserializeAsyncEnumerable<TRow>(stream, _options, cancellationToken)
+      .ConfigureAwait(false))
     {
       if (item is null)
       {

--- a/src/core/Flowthru.Core/Data/Storage/JsonFormatSerializer.cs
+++ b/src/core/Flowthru.Core/Data/Storage/JsonFormatSerializer.cs
@@ -29,7 +29,7 @@ namespace Flowthru.Data.Storage;
 /// </remarks>
 /// <typeparam name="TRow">The row schema type.</typeparam>
 public sealed class JsonFormatSerializer<TRow>
-  : IFormatSerializer<TRow>, ISupportsIScalar, ISupportsNested
+  : IFormatSerializer<TRow>, IFormatStreamReader<TRow>, ISupportsIScalar, ISupportsNested
   where TRow : notnull, IStructuredSerializable
 {
   private readonly JsonSerializerOptions _options;
@@ -61,7 +61,15 @@ public sealed class JsonFormatSerializer<TRow>
   public JsonSerializerOptions Options => _options;
 
   /// <inheritdoc/>
-  public StorageTraits Traits => new() { CanStream = false };
+  /// <remarks>
+  /// Streaming: the read path is genuinely incremental via
+  /// <see cref="JsonSerializer.DeserializeAsyncEnumerable{TValue}(Stream, JsonSerializerOptions?, CancellationToken)"/>,
+  /// which yields top-level array elements without materialising the whole
+  /// array — so the serializer honestly implements
+  /// <see cref="IFormatStreamReader{TRow}"/> and declares
+  /// <see cref="StorageTraits.CanStream"/> = <c>true</c>.
+  /// </remarks>
+  public StorageTraits Traits => new() { CanStream = true };
 
   /// <inheritdoc/>
   public async IAsyncEnumerable<TRow> DeserializeRows(

--- a/src/core/Flowthru.Core/Data/Storage/SeekableSpill.cs
+++ b/src/core/Flowthru.Core/Data/Storage/SeekableSpill.cs
@@ -1,0 +1,85 @@
+namespace Flowthru.Data.Storage;
+
+/// <summary>
+/// Makes a forward-only byte source seekable <em>without</em> holding it
+/// entirely in RAM. Seek-required formats (Parquet, Excel) need random access —
+/// the footer / workbook directory lives at the end of the object — but an
+/// S3 / HTTP response body is forward-only. Rather than buffer the whole object
+/// into a <see cref="MemoryStream"/> (O(object) RAM), spill it to a bounded temp
+/// file (O(object) disk, O(buffer) RAM) and hand back a seekable
+/// <see cref="FileStream"/>. Already-seekable sources pass through untouched.
+/// </summary>
+/// <remarks>
+/// This is the shared "make-seekable" primitive (ADR-0023) so Parquet and Excel
+/// don't each carry their own copy/seek/dispose logic. The temp file is created
+/// with <see cref="FileOptions.DeleteOnClose"/>, so <see cref="DisposeAsync"/>
+/// deletes it — and the lifetime is owned by the caller's <c>await using</c>,
+/// which for a streaming read is the <c>FlowSource</c> bracket.
+/// </remarks>
+public sealed class SeekableSpill : IAsyncDisposable
+{
+  private readonly bool _ownsStream;
+
+  private SeekableSpill(Stream stream, bool ownsStream)
+  {
+    Stream = stream;
+    _ownsStream = ownsStream;
+  }
+
+  /// <summary>The seekable stream, positioned at the start.</summary>
+  public Stream Stream { get; }
+
+  /// <summary>
+  /// Returns a seekable view of <paramref name="source"/>. If it is already
+  /// seekable it is returned as-is (ownership stays with the caller, so
+  /// <see cref="DisposeAsync"/> leaves it open). Otherwise the source is spilled
+  /// to a temp file (auto-deleted on dispose) and a <see cref="FileStream"/> is
+  /// returned.
+  /// </summary>
+  public static async ValueTask<SeekableSpill> CreateAsync(
+    Stream source,
+    CancellationToken cancellationToken = default
+  )
+  {
+    if (source is null) throw new ArgumentNullException(nameof(source));
+
+    if (source.CanSeek)
+    {
+      source.Position = 0;
+      return new SeekableSpill(source, ownsStream: false);
+    }
+
+    var file = new FileStream(
+      Path.GetTempFileName(),
+      FileMode.Create,
+      FileAccess.ReadWrite,
+      FileShare.None,
+      bufferSize: 81920,
+      FileOptions.Asynchronous | FileOptions.DeleteOnClose
+    );
+    try
+    {
+      await source.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+      file.Position = 0;
+    }
+    catch
+    {
+      await file.DisposeAsync().ConfigureAwait(false); // DeleteOnClose removes the temp file
+      throw;
+    }
+
+    return new SeekableSpill(file, ownsStream: true);
+  }
+
+  /// <summary>
+  /// Disposes the spilled temp file (when this spill owns one). A pass-through
+  /// of an already-seekable caller stream is left open — the caller owns it.
+  /// </summary>
+  public async ValueTask DisposeAsync()
+  {
+    if (_ownsStream)
+    {
+      await Stream.DisposeAsync().ConfigureAwait(false);
+    }
+  }
+}

--- a/src/core/Flowthru.Core/Flow/FlowBuilderStreamingExtensions.cs
+++ b/src/core/Flowthru.Core/Flow/FlowBuilderStreamingExtensions.cs
@@ -1,0 +1,47 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Prelude;
+
+namespace Flowthru.Flow;
+
+/// <summary>
+/// Intent-level streaming helpers on <see cref="FlowBuilder"/>.
+/// </summary>
+public static class FlowBuilderStreamingExtensions
+{
+  /// <summary>
+  /// Wire a streaming source item to a batch sink as an <em>on-DAG</em> identity
+  /// step: the source streams row-by-row and the sink writes batches, in
+  /// O(batch) memory, with the load participating in scheduling, caching, and
+  /// pre-flight like any other step. The Flow developer writes intent —
+  /// <c>AddBulkLoad(orders.AsStream(), sink)</c> — not <c>Compile</c>/<c>Into</c>
+  /// mechanics, and never the off-DAG form that would bypass the scheduler and
+  /// the read cap.
+  /// </summary>
+  /// <typeparam name="T">The row type flowing from source to sink.</typeparam>
+  /// <param name="builder">The flow builder.</param>
+  /// <param name="source">A streaming source view (from <c>item.AsStream()</c>).</param>
+  /// <param name="sink">The batch sink (e.g. an EFCore.Bulk streaming sink).</param>
+  /// <param name="label">Optional step label; defaults to <c>BulkLoad_{source.Label}</c>.</param>
+  /// <param name="sinkLabel">Optional output-item label; defaults to <c>{source.Label}.sink</c>.</param>
+  public static FlowBuilder AddBulkLoad<T>(
+    this FlowBuilder builder,
+    IReadOnlyItem<FlowSource<T>> source,
+    IFlowSink<T> sink,
+    string? label = null,
+    string? sinkLabel = null
+  )
+    where T : notnull
+  {
+    if (builder is null) throw new ArgumentNullException(nameof(builder));
+    if (source is null) throw new ArgumentNullException(nameof(source));
+    if (sink is null) throw new ArgumentNullException(nameof(sink));
+
+    var output = new FlowSinkItem<T>(sinkLabel ?? $"{source.Label}.sink", sink);
+    return builder.AddStep<FlowSource<T>, FlowSource<T>>(
+      label: label ?? $"BulkLoad_{source.Label}",
+      transform: static s => s,
+      inputs: source,
+      outputs: output
+    );
+  }
+}

--- a/src/core/Flowthru.Core/Prelude/FlowIO.cs
+++ b/src/core/Flowthru.Core/Prelude/FlowIO.cs
@@ -185,6 +185,16 @@ public sealed class FlowIO<A>
       };
     });
 
+  /// <summary>
+  /// Run this effect with cancellation suppressed
+  /// (<see cref="CancellationToken.None"/>), so it completes even when the
+  /// ambient token is already cancelled. Used for cleanup/release effects that
+  /// must run on every exit path — including cancellation — where a
+  /// <see cref="Lift"/>/<see cref="LiftAsync"/> body would otherwise
+  /// short-circuit on the cancelled token.
+  /// </summary>
+  public FlowIO<A> Uncancellable() => new(_ => _run(CancellationToken.None));
+
   // ───────────────────────────────────────────────────────────────────────
   // LINQ syntax (monadic; short-circuits on failure)
   // ───────────────────────────────────────────────────────────────────────

--- a/src/core/Flowthru.Core/Prelude/FlowSource.cs
+++ b/src/core/Flowthru.Core/Prelude/FlowSource.cs
@@ -156,6 +156,59 @@ public readonly struct FlowSourceCompiler<A>
   public FlowIO<IReadOnlyList<A>> ToList() =>
     Fold(new List<A>(), static (list, a) => { list.Add(a); return list; })
       .Map(static list => (IReadOnlyList<A>)list);
+
+  /// <summary>
+  /// Drive the stream into a batch sink inside the effect envelope: open, write
+  /// each <see cref="IFlowSink{T}.BatchSize"/>-sized batch as elements arrive,
+  /// then complete. The sink is disposed on every exit path (so it can roll
+  /// back when completion is not reached), and the byte source is released
+  /// after. Pull-based, so a slow sink paces a fast source in O(batch) memory.
+  /// </summary>
+  public FlowIO<FlowUnit> Into(IFlowSink<A> sink)
+  {
+    var source = _source;
+    var batchSize = Math.Max(1, sink.BatchSize);
+    return FlowSource.BracketUse(
+      source.Resource,
+      scope =>
+        FlowIO.LiftAsync(
+          async ct =>
+          {
+            var buffer = new List<A>(batchSize);
+            try
+            {
+              await sink.OpenAsync(ct).ConfigureAwait(false);
+              await foreach (var a in source.Pull(scope, ct).WithCancellation(ct).ConfigureAwait(false))
+              {
+                buffer.Add(a);
+                if (buffer.Count >= batchSize)
+                {
+                  await sink.WriteBatchAsync(buffer, ct).ConfigureAwait(false);
+                  buffer.Clear();
+                }
+              }
+
+              if (buffer.Count > 0)
+              {
+                await sink.WriteBatchAsync(buffer, ct).ConfigureAwait(false);
+              }
+
+              await sink.CompleteAsync(ct).ConfigureAwait(false);
+              return FlowUnit.Default;
+            }
+            finally
+            {
+              // The finally guarantees disposal on every path: success (cleanup
+              // after commit) and failure/cancellation (abort/rollback, since
+              // CompleteAsync was not reached).
+              await sink.DisposeAsync().ConfigureAwait(false);
+            }
+          },
+          source: "FlowSource.Into"
+        )
+        .MapError(err => FlowSource.UnwrapFailure(err, source.MapErr))
+    );
+  }
 }
 
 /// <summary>Factories, combinators, and internal machinery for <see cref="FlowSource{A}"/>.</summary>

--- a/src/core/Flowthru.Core/Prelude/FlowSource.cs
+++ b/src/core/Flowthru.Core/Prelude/FlowSource.cs
@@ -1,0 +1,369 @@
+// Derived (in design) from LanguageExt v5's SourceT (https://github.com/louthy/language-ext)
+// by Paul Louth. Copyright (c) 2014-2025 Paul Louth. MIT License — see LICENSE-LanguageExt.md.
+// Simplified for Flowthru, mirroring the FlowIO fork:
+//   - Failure type is RuntimeError (no generic E; no Error abstraction).
+//   - No HKT (K<F, A>) / MonadIO — FlowSource is not polymorphic over a monad type-class.
+//   - Not a transducer/DSL node hierarchy — FlowSource wraps a pull function directly.
+//   - Consumption is compile-to-FlowIO; a bare IAsyncEnumerable is never exposed publicly.
+
+using System.Runtime.CompilerServices;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Prelude;
+
+/// <summary>
+/// The Flowthru streaming effect type — the streaming sibling of
+/// <see cref="FlowIO{A}"/>. A <c>FlowSource&lt;A&gt;</c> is a lazy,
+/// resource-safe, error-as-value description of a stream of
+/// <typeparamref name="A"/> values whose <em>only</em> consumption path is
+/// <see cref="Compile"/>, which lands it back inside a <see cref="FlowIO{A}"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why compile-to-<see cref="FlowIO{A}"/>.</strong> Enumeration runs
+/// entirely inside the <see cref="FlowIO{A}"/> returned by a
+/// <see cref="FlowSourceCompiler{A}"/> terminal, so the framework — not the
+/// caller — owns the <c>try</c>/<c>finally</c>. Errors surface as values,
+/// resources release deterministically, and cancellation threads through, all
+/// by construction. A bare <see cref="IAsyncEnumerable{T}"/> is never handed
+/// out (the pull function is <c>internal</c>).
+/// </para>
+/// <para>
+/// <strong>Deferred acquisition.</strong> The underlying byte source is a
+/// <see cref="FlowResource{TScope}"/> whose acquire runs on the first pull —
+/// i.e. only when the compiled <see cref="FlowIO{A}"/> is run. A
+/// <c>FlowSource</c> that is built but never compiled/run acquires nothing and
+/// therefore leaks nothing; a compiled-but-never-run effect is likewise inert.
+/// </para>
+/// <para>
+/// <strong>Error channel.</strong> By default a failure aborts the stream and
+/// surfaces at compile as a terminal <see cref="RuntimeError"/>
+/// (<c>EffResult.Failure</c>). For "keep the good rows, quarantine the bad",
+/// use <see cref="Attempt"/> to move failures in-band as
+/// <c>FlowSource&lt;EffResult&lt;A&gt;&gt;</c> elements, then
+/// <c>SkipErrors</c>/<c>Rethrow</c> to collapse back.
+/// </para>
+/// <para>
+/// <strong>Cancel-mid-acquire leak window.</strong> Release is guaranteed on
+/// every path <em>once acquire has produced a scope</em>. If cancellation
+/// lands after acquire begins but before it returns a scope, no scope exists
+/// to release — the underlying resource's own disposal (e.g. a temp file's
+/// finalizer) is the backstop, not a masking primitive <see cref="FlowIO{A}"/>
+/// does not have.
+/// </para>
+/// </remarks>
+/// <typeparam name="A">The element type produced by the stream.</typeparam>
+public sealed class FlowSource<A>
+{
+  private readonly IFlowResource _resource;
+  private readonly Func<object?, CancellationToken, IAsyncEnumerable<A>> _pull;
+  private readonly Func<RuntimeError, RuntimeError> _mapError;
+
+  internal FlowSource(
+    IFlowResource resource,
+    Func<object?, CancellationToken, IAsyncEnumerable<A>> pull,
+    Func<RuntimeError, RuntimeError> mapError
+  )
+  {
+    _resource = resource;
+    _pull = pull;
+    _mapError = mapError;
+  }
+
+  // Framework-internal views. These are how sibling combinators (error
+  // bridges) rebuild a source without draining it — never public, so no bare
+  // IAsyncEnumerable escapes the type.
+  internal IFlowResource Resource => _resource;
+  internal Func<object?, CancellationToken, IAsyncEnumerable<A>> Pull => _pull;
+  internal Func<RuntimeError, RuntimeError> MapErr => _mapError;
+
+  // ── Lazy combinators ──────────────────────────────────────────────────
+
+  /// <summary>Transform each element. Lazy — no acquisition or pull happens.</summary>
+  public FlowSource<B> Map<B>(Func<A, B> f) =>
+    new(_resource, (scope, ct) => _pull(scope, ct).Select(f), _mapError);
+
+  /// <summary>Keep only elements matching <paramref name="predicate"/>. Lazy.</summary>
+  public FlowSource<A> Where(Func<A, bool> predicate) =>
+    new(_resource, (scope, ct) => _pull(scope, ct).Where(predicate), _mapError);
+
+  /// <summary>
+  /// Transform the terminal failure. Composes with any existing mapping
+  /// (existing applied first). Used by the storage layer to translate a
+  /// provider exception into a typed <see cref="RuntimeError.SchemaMismatch"/>.
+  /// </summary>
+  public FlowSource<A> MapError(Func<RuntimeError, RuntimeError> f) =>
+    new(_resource, _pull, e => f(_mapError(e)));
+
+  /// <summary>
+  /// Move failures in-band: the stream can no longer fail terminally; a
+  /// failure becomes a trailing <c>EffResult.Failure</c> element after which
+  /// the stream stops (fs2 <c>attempt</c> semantics).
+  /// </summary>
+  public FlowSource<EffResult<A>> Attempt() =>
+    new(_resource, (scope, ct) => FlowSource.AttemptImpl(_pull(scope, ct), _mapError, ct), FlowSource.Id);
+
+  /// <summary>The sole consumption path — lands the stream back in a <see cref="FlowIO{A}"/>.</summary>
+  public FlowSourceCompiler<A> Compile() => new(this);
+}
+
+/// <summary>
+/// Terminals that compile a <see cref="FlowSource{A}"/> into a
+/// <see cref="FlowIO{A}"/>. Each drives the stream inside the effect envelope:
+/// the bracketed source is acquired on the first pull and released on every
+/// exit path (completion, failure, cancellation, early termination).
+/// </summary>
+/// <typeparam name="A">The element type of the compiled stream.</typeparam>
+public readonly struct FlowSourceCompiler<A>
+{
+  private readonly FlowSource<A> _source;
+
+  internal FlowSourceCompiler(FlowSource<A> source) => _source = source;
+
+  /// <summary>
+  /// Left-fold the stream into a single value inside the effect envelope.
+  /// The bracketed source is acquired on first pull; a mid-stream throw
+  /// becomes a typed <see cref="RuntimeError"/> failure.
+  /// </summary>
+  public FlowIO<S> Fold<S>(S seed, Func<S, A, S> step)
+  {
+    var source = _source;
+    return FlowSource.BracketUse(
+      source.Resource,
+      scope =>
+        FlowIO.LiftAsync(
+          async ct =>
+          {
+            var acc = seed;
+            await foreach (var a in source.Pull(scope, ct).WithCancellation(ct).ConfigureAwait(false))
+            {
+              acc = step(acc, a);
+            }
+
+            return acc;
+          },
+          source: "FlowSource"
+        )
+        .MapError(err => FlowSource.UnwrapFailure(err, source.MapErr))
+    );
+  }
+
+  /// <summary>Run the stream for its effects, discarding elements.</summary>
+  public FlowIO<FlowUnit> Drain() =>
+    Fold(FlowUnit.Default, static (unit, _) => unit);
+
+  /// <summary>Materialise the whole stream into a list. This is O(dataset) by intent — the visible way to collect.</summary>
+  public FlowIO<IReadOnlyList<A>> ToList() =>
+    Fold(new List<A>(), static (list, a) => { list.Add(a); return list; })
+      .Map(static list => (IReadOnlyList<A>)list);
+}
+
+/// <summary>Factories, combinators, and internal machinery for <see cref="FlowSource{A}"/>.</summary>
+public static class FlowSource
+{
+  /// <summary>The identity error map — the default for an un-translated source.</summary>
+  internal static readonly Func<RuntimeError, RuntimeError> Id = static e => e;
+
+  /// <summary>
+  /// Build a source from a bare pull function with no managed resource. The
+  /// pull is invoked lazily on compile-and-run.
+  /// </summary>
+  public static FlowSource<A> Lift<A>(Func<CancellationToken, IAsyncEnumerable<A>> pull) =>
+    new(FlowResource.Empty, (_, ct) => pull(ct), Id);
+
+  /// <summary>
+  /// Build a source over a bracketed byte resource. The resource's acquire
+  /// runs on the first pull and its release runs on every exit path.
+  /// </summary>
+  public static FlowSource<A> Bracket<TScope, A>(
+    FlowResource<TScope> resource,
+    Func<TScope, CancellationToken, IAsyncEnumerable<A>> pull
+  ) =>
+    new(resource, (scope, ct) => pull((TScope)scope!, ct), Id);
+
+  /// <summary>The empty stream.</summary>
+  public static FlowSource<A> Empty<A>() =>
+    Lift<A>(static _ => AsyncEnumerable.Empty<A>());
+
+  /// <summary>Build a source from an in-memory sequence (test/sample convenience).</summary>
+  public static FlowSource<A> FromEnumerable<A>(IEnumerable<A> items) =>
+    Lift<A>(ct => FromEnumerableImpl(items, ct));
+
+  // ── Internal machinery ────────────────────────────────────────────────
+
+  /// <summary>
+  /// The pull-scoped bracket over the type-erased <see cref="IFlowResource"/>.
+  /// Mirrors <see cref="FlowResource{TScope}.Use{TResult}"/> for the untyped
+  /// view: acquire → body → release-on-every-path, body error wins.
+  /// </summary>
+  internal static FlowIO<S> BracketUse<S>(IFlowResource resource, Func<object?, FlowIO<S>> body) =>
+    resource.AcquireUntyped().Bind(scope =>
+      body(scope)
+        .Catch(bodyError =>
+          // Release must run even when cancellation is what aborted the body,
+          // so suppress cancellation on the release effect.
+          resource.ReleaseUntyped(scope, bodyError).Uncancellable()
+            .Catch(static _ => FlowIO<FlowUnit>.Pure(FlowUnit.Default))
+            .Bind<S>(_ => FlowIO<S>.Fail(bodyError)))
+        .Bind(value =>
+          resource.ReleaseUntyped(scope, null).Uncancellable().Map(_ => value)));
+
+  /// <summary>
+  /// Unwrap the driver's boundary error. <see cref="FlowIO{A}.LiftAsync"/>
+  /// wraps every thrown exception as <see cref="RuntimeError.External"/>; a
+  /// <see cref="FlowSourceFailure"/> carries an already-typed inner error to
+  /// restore, and the source's own translator is applied last.
+  /// </summary>
+  internal static RuntimeError UnwrapFailure(RuntimeError err, Func<RuntimeError, RuntimeError> mapError) =>
+    err switch
+    {
+      RuntimeError.External { Cause: FlowSourceFailure fsf } => mapError(fsf.Error),
+      _ => mapError(err),
+    };
+
+  internal static async IAsyncEnumerable<EffResult<A>> AttemptImpl<A>(
+    IAsyncEnumerable<A> source,
+    Func<RuntimeError, RuntimeError> mapError,
+    [EnumeratorCancellation] CancellationToken ct
+  )
+  {
+    await using var e = source.GetAsyncEnumerator(ct);
+    while (true)
+    {
+      // C# forbids `yield` inside a catch, so the try/catch only *captures* the
+      // outcome; the yield happens afterwards.
+      bool moved;
+      A current = default!;
+      EffResult<A>? failure = null;
+      try
+      {
+        moved = await e.MoveNextAsync().ConfigureAwait(false);
+        if (moved)
+        {
+          current = e.Current;
+        }
+      }
+      // Cancellation is a control signal, not a dead-letter row — let it abort.
+      catch (OperationCanceledException)
+      {
+        throw;
+      }
+      catch (FlowSourceFailure fsf)
+      {
+        moved = false;
+        failure = new EffResult<A>.Failure(mapError(fsf.Error));
+      }
+      catch (Exception ex)
+      {
+        moved = false;
+        failure = new EffResult<A>.Failure(mapError(new RuntimeError.External("FlowSource", ex)));
+      }
+
+      if (failure is not null)
+      {
+        yield return failure;
+        yield break;
+      }
+
+      if (!moved)
+      {
+        yield break;
+      }
+
+      yield return new EffResult<A>.Success(current);
+    }
+  }
+
+  private static async IAsyncEnumerable<A> FromEnumerableImpl<A>(
+    IEnumerable<A> items,
+    [EnumeratorCancellation] CancellationToken ct
+  )
+  {
+    await Task.CompletedTask.ConfigureAwait(false); // async-iterator requirement; no real await
+    foreach (var item in items)
+    {
+      ct.ThrowIfCancellationRequested();
+      yield return item;
+    }
+  }
+}
+
+/// <summary>
+/// Error-channel bridges between the terminal-failure and per-item-failure
+/// representations. Extension methods (rather than instance methods) because
+/// they are only valid where the element type is itself an
+/// <see cref="EffResult{A}"/>.
+/// </summary>
+public static class FlowSourceErrorBridges
+{
+  /// <summary>
+  /// Collapse an in-band stream back to a terminal-failure stream: a
+  /// <c>Failure</c> element re-raises as the terminal error and stops the
+  /// stream (TryStream <c>try_next</c> semantics).
+  /// </summary>
+  public static FlowSource<X> Rethrow<X>(this FlowSource<EffResult<X>> source) =>
+    new(source.Resource, (scope, ct) => RethrowImpl(source.Pull(scope, ct), ct), source.MapErr);
+
+  /// <summary>
+  /// Drop <c>Failure</c> elements (optionally reporting each) and keep the
+  /// successes — the dead-letter path.
+  /// </summary>
+  public static FlowSource<X> SkipErrors<X>(
+    this FlowSource<EffResult<X>> source,
+    Action<RuntimeError>? onError = null
+  ) =>
+    new(source.Resource, (scope, ct) => SkipErrorsImpl(source.Pull(scope, ct), onError, ct), source.MapErr);
+
+  private static async IAsyncEnumerable<X> RethrowImpl<X>(
+    IAsyncEnumerable<EffResult<X>> source,
+    [EnumeratorCancellation] CancellationToken ct
+  )
+  {
+    await foreach (var r in source.WithCancellation(ct).ConfigureAwait(false))
+    {
+      switch (r)
+      {
+        case EffResult<X>.Success s:
+          yield return s.Value;
+          break;
+        case EffResult<X>.Failure f:
+          throw new FlowSourceFailure(f.Error);
+      }
+    }
+  }
+
+  private static async IAsyncEnumerable<X> SkipErrorsImpl<X>(
+    IAsyncEnumerable<EffResult<X>> source,
+    Action<RuntimeError>? onError,
+    [EnumeratorCancellation] CancellationToken ct
+  )
+  {
+    await foreach (var r in source.WithCancellation(ct).ConfigureAwait(false))
+    {
+      switch (r)
+      {
+        case EffResult<X>.Success s:
+          yield return s.Value;
+          break;
+        case EffResult<X>.Failure f:
+          onError?.Invoke(f.Error);
+          break;
+      }
+    }
+  }
+}
+
+/// <summary>
+/// Internal carrier that lets a producer fail the stream terminally with an
+/// already-typed <see cref="RuntimeError"/>. The compile driver unwraps it
+/// (see <see cref="FlowSource.UnwrapFailure"/>) so the typed error survives
+/// the throw-across-<c>yield</c> boundary rather than flattening to
+/// <see cref="RuntimeError.External"/>.
+/// </summary>
+internal sealed class FlowSourceFailure : Exception
+{
+  public RuntimeError Error { get; }
+
+  public FlowSourceFailure(RuntimeError error)
+    : base(error.Message) => Error = error;
+}

--- a/src/core/Flowthru.Core/Prelude/IFlowSink.cs
+++ b/src/core/Flowthru.Core/Prelude/IFlowSink.cs
@@ -1,0 +1,36 @@
+namespace Flowthru.Prelude;
+
+/// <summary>
+/// Consumes a compiled <see cref="FlowSource{A}"/> batch-at-a-time — the sink
+/// counterpart to the source. Driven by <see cref="FlowSourceCompiler{A}.Into"/>
+/// inside the effect envelope: <see cref="OpenAsync"/> once, then
+/// <see cref="WriteBatchAsync"/> per batch as elements arrive, then
+/// <see cref="CompleteAsync"/>. <see cref="System.IAsyncDisposable.DisposeAsync"/>
+/// runs on every exit path and must <em>abort</em> (e.g. roll back an open
+/// transaction) when <see cref="CompleteAsync"/> was not reached.
+/// </summary>
+/// <remarks>
+/// The writer owns its batch size (<see cref="BatchSize"/>), so the driver
+/// re-chunks the row-at-a-time stream into the writer's preferred batches —
+/// decoupling the read batch (e.g. a Parquet row group) from the write batch
+/// (e.g. a Postgres <c>COPY</c>).
+/// </remarks>
+/// <typeparam name="T">The element type consumed by the sink.</typeparam>
+public interface IFlowSink<in T> : IAsyncDisposable
+{
+  /// <summary>The number of elements per <see cref="WriteBatchAsync"/> call.</summary>
+  int BatchSize { get; }
+
+  /// <summary>Begin consumption (e.g. open a transaction / <c>COPY</c> writer).</summary>
+  ValueTask OpenAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Write one batch of elements. The batch is valid only for the duration of
+  /// the call — the driver may reuse the backing buffer afterwards, so a sink
+  /// that retains rows must copy them.
+  /// </summary>
+  ValueTask WriteBatchAsync(IReadOnlyList<T> batch, CancellationToken cancellationToken);
+
+  /// <summary>Finish consumption successfully (e.g. commit the transaction).</summary>
+  ValueTask CompleteAsync(CancellationToken cancellationToken);
+}

--- a/src/core/Flowthru.Core/Prelude/README.md
+++ b/src/core/Flowthru.Core/Prelude/README.md
@@ -23,6 +23,12 @@ containing only the FP primitives Flowthru actively uses.
 - `Has<TRuntime, TCapability>` — capability constraint trait (Eff-specialised)
 - `Validated<E, T>` — error-accumulating applicative for pre-flight checks
 - `Unit` — bound type for effects with no meaningful result
+- `FlowSource<T>` — the streaming sibling of the effect type: a lazy,
+  resource-safe stream consumed by compiling back into `FlowIO`. Its minimum
+  shape earns a Prelude seat because streaming is a first-class grain (bounded
+  `O(batch)` reads on memory-constrained hosts); see
+  [ADR-0023](/.claude/docs/adr/0023-streaming-reads-as-catalog-item-type.md)
+  for why it is vendored, not taken as a LanguageExt dependency
 
 **Excluded** (and not planned):
 
@@ -31,7 +37,8 @@ containing only the FP primitives Flowthru actively uses.
 - Monad transformer stack (`StateT`, `WriterT`, `ReaderT`, `RWST`, …)
 - `Either`, `Option`, `Try`, `Fin` — Flowthru's `RuntimeError` ADT and
   `Validated<E, T>` cover these roles
-- Free monads, Pipes, Streams
+- Free monads and Pipes (but **not** Streams — see `FlowSource<T>` above,
+  added under ADR-0023)
 - Immutable collections (`Seq`, `Lst`, `Iterable`, `HashMap`, …)
 
 ## Maintenance policy

--- a/src/core/Flowthru.Core/Step/Marshalling/IContainerMarshaller.cs
+++ b/src/core/Flowthru.Core/Step/Marshalling/IContainerMarshaller.cs
@@ -20,13 +20,14 @@ namespace Flowthru.Step.Marshalling;
 /// interfaces it implements.
 /// </para>
 /// <para>
-/// Extensions declaring <see cref="StepContainerKind.Queryable"/> or
-/// <see cref="StepContainerKind.AsyncStream"/> additionally implement
-/// <see cref="IQueryableMarshaller{TExtension}"/> or
-/// <see cref="IAsyncStreamMarshaller{TExtension}"/> respectively —
-/// those are opt-in markers and the floor's
-/// <see cref="IContainerMarshaller{TExtension}"/> is the only one
-/// strictly required.
+/// Extensions declaring <see cref="StepContainerKind.Queryable"/>
+/// additionally implement
+/// <see cref="IQueryableMarshaller{TExtension}"/> — an opt-in marker;
+/// the floor's <see cref="IContainerMarshaller{TExtension}"/> is the
+/// only one strictly required. Streaming
+/// (<see cref="StepContainerKind.Source"/>) has no marshaller marker:
+/// per ADR-0023 a <c>FlowSource&lt;T&gt;</c> is consumed by compiling
+/// back into <c>FlowIO</c>, not shuttled across a marker seam.
 /// </para>
 /// </remarks>
 /// <typeparam name="TExtension">
@@ -49,18 +50,5 @@ public interface IContainerMarshaller<TExtension> where TExtension : IStepExtens
 /// The step extension's descriptor class.
 /// </typeparam>
 public interface IQueryableMarshaller<TExtension> where TExtension : IStepExtension
-{
-}
-
-/// <summary>
-/// Marker interface declaring that <typeparamref name="TExtension"/>
-/// can marshal <see cref="StepContainerKind.AsyncStream"/> catalog
-/// items (i.e. <c>IItem&lt;IAsyncEnumerable&lt;TRow&gt;&gt;</c>).
-/// Opt-in; not part of the minimum-coverage floor.
-/// </summary>
-/// <typeparam name="TExtension">
-/// The step extension's descriptor class.
-/// </typeparam>
-public interface IAsyncStreamMarshaller<TExtension> where TExtension : IStepExtension
 {
 }

--- a/src/core/Flowthru.Core/Step/StepContainerKind.cs
+++ b/src/core/Flowthru.Core/Step/StepContainerKind.cs
@@ -20,8 +20,8 @@ namespace Flowthru.Step;
 /// containers carry higher bits than less-specific ones. Resolution
 /// at the catalog-side introspection layer
 /// (<c>Flowthru.Data.Catalog.Item.ContainerKindOf</c>) walks
-/// container interfaces in the order
-/// <see cref="AsyncStream"/> → <see cref="Queryable"/> →
+/// container shapes in the order
+/// <see cref="Source"/> → <see cref="Queryable"/> →
 /// <see cref="Enumerable"/> → <see cref="Singleton"/>, picking the
 /// most specific match. <see cref="System.Linq.IQueryable{T}"/> is
 /// itself <see cref="System.Collections.Generic.IEnumerable{T}"/>-
@@ -57,8 +57,14 @@ public enum StepContainerKind
   Queryable = 1 << 2,
 
   /// <summary>
-  /// <c>IAsyncEnumerable&lt;T&gt;</c> — streaming inputs. Nice-to-have;
-  /// not part of the Phase 9 minimum floor.
+  /// A <c>Flowthru.Prelude.FlowSource&lt;T&gt;</c> — the lazy,
+  /// resource-safe streaming catalog payload produced by
+  /// <c>.AsStream()</c>, whose sole consumption path is
+  /// compile-to-<c>FlowIO</c>. Supersedes the removed bare-
+  /// <c>IAsyncEnumerable</c> <c>AsyncStream</c> kind (see ADR-0023):
+  /// <c>FlowSource</c> keeps enumeration inside the effect envelope,
+  /// so errors-as-values, disposal, and cancellation are preserved by
+  /// construction. Nice-to-have; not part of the Phase 9 minimum floor.
   /// </summary>
-  AsyncStream = 1 << 3,
+  Source = 1 << 3,
 }

--- a/src/core/Flowthru.FUnit/FUnitContext.cs
+++ b/src/core/Flowthru.FUnit/FUnitContext.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Flowthru.Data.Catalog;
 using Flowthru.Data.Storage;
 using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Flowthru.Step.Testing;
@@ -99,6 +100,85 @@ public class FUnitContext : IDisposable
     TInput input,
     CancellationToken cancellationToken = default
   ) => step(input, cancellationToken);
+
+  // ===========================================================================
+  // Streaming (FlowSource) invocation
+  //
+  // The streaming siblings of Invoke/InvokeAsync. A FlowSource's only exit is
+  // Compile(), whose terminals return a FlowIO run with .Run(ct) → EffResult.
+  // These helpers compile/drain a source (or a step returning one) and unwind
+  // the EffResult to a materialised list — mirroring how Validate unwinds an
+  // EffResult<ValidationResult> for assertion sites.
+  // ===========================================================================
+
+  /// <summary>
+  /// Compile and run a <see cref="FlowSource{A}"/> to a materialised list,
+  /// unwinding the <see cref="EffResult{A}"/> for assertion. A terminal
+  /// <see cref="RuntimeError"/> (a failed compile) surfaces as a thrown
+  /// <see cref="InvalidOperationException"/> so <c>Assert.CatchAsync</c> works;
+  /// use <see cref="RunStream"/> to inspect the typed error instead.
+  /// </summary>
+  protected async Task<IReadOnlyList<A>> InvokeStream<A>(
+    FlowSource<A> source,
+    CancellationToken cancellationToken = default
+  )
+  {
+    var result = await source.Compile().ToList().Run(cancellationToken).ConfigureAwait(false);
+    return result switch
+    {
+      EffResult<IReadOnlyList<A>>.Success ok => ok.Value,
+      EffResult<IReadOnlyList<A>>.Failure failure =>
+        throw new InvalidOperationException(failure.Error.Message),
+      _ => throw new InvalidOperationException("Unreachable: EffResult is a closed sum"),
+    };
+  }
+
+  /// <summary>
+  /// Invoke a streaming step transform over an in-memory sample and materialise
+  /// the output — the streaming analogue of <see cref="Invoke{TInput,TOutput}"/>.
+  /// </summary>
+  protected Task<IReadOnlyList<TOutput>> InvokeStream<TInput, TOutput>(
+    Func<FlowSource<TInput>, FlowSource<TOutput>> step,
+    IEnumerable<TInput> input,
+    CancellationToken cancellationToken = default
+  ) => InvokeStream(step(FlowSource.FromEnumerable(input)), cancellationToken);
+
+  /// <summary>
+  /// Invoke a streaming step transform over an existing <see cref="FlowSource{A}"/>
+  /// input and materialise the output.
+  /// </summary>
+  protected Task<IReadOnlyList<TOutput>> InvokeStream<TInput, TOutput>(
+    Func<FlowSource<TInput>, FlowSource<TOutput>> step,
+    FlowSource<TInput> input,
+    CancellationToken cancellationToken = default
+  ) => InvokeStream(step(input), cancellationToken);
+
+  /// <summary>
+  /// Compile and run a <see cref="FlowSource{A}"/>, returning the raw
+  /// <see cref="EffResult{A}"/> so a test can assert <em>both</em> error modes:
+  /// a <c>Success</c> list of rows, or a terminal <c>Failure</c> carrying the
+  /// typed <see cref="RuntimeError"/> from a failed compile. For per-item
+  /// (dead-letter) failures, run a <c>FlowSource&lt;EffResult&lt;T&gt;&gt;</c>
+  /// through <see cref="InvokeStream{A}"/> and assert on each element, or
+  /// collapse it with <c>SkipErrors</c>/<c>Rethrow</c> first.
+  /// </summary>
+  protected Task<EffResult<IReadOnlyList<A>>> RunStream<A>(
+    FlowSource<A> source,
+    CancellationToken cancellationToken = default
+  ) => source.Compile().ToList().Run(cancellationToken);
+
+  /// <summary>
+  /// Drive a <see cref="FlowSource{A}"/> into a sink inside the effect envelope
+  /// and return the raw <see cref="EffResult{A}"/>. Use with a
+  /// <see cref="RecordingSink{T}"/> (or another <see cref="IFlowSink{T}"/> test
+  /// double) to observe the sink's batch lifecycle and its release on every exit
+  /// path.
+  /// </summary>
+  protected Task<EffResult<FlowUnit>> DrainInto<A>(
+    FlowSource<A> source,
+    IFlowSink<A> sink,
+    CancellationToken cancellationToken = default
+  ) => source.Compile().Into(sink).Run(cancellationToken);
 
   /// <summary>
   /// Run pre-flight <see cref="INode.Validate"/> on any DAG node and

--- a/src/core/Flowthru.FUnit/FlowSourceTesting.cs
+++ b/src/core/Flowthru.FUnit/FlowSourceTesting.cs
@@ -1,0 +1,175 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Step.Testing;
+
+/// <summary>
+/// Streaming-test affordances for <see cref="FlowSource{T}"/> — the streaming
+/// sibling of the eager <see cref="SampleBuilder"/> helpers. Lets a step test
+/// lift in-memory samples into a stream, observe the pull-scoped bracket's
+/// release, and observe a sink's batch lifecycle, without leaving the test
+/// framework.
+/// </summary>
+public static class FlowSourceTesting
+{
+  /// <summary>
+  /// Lift an in-memory sample sequence into a <see cref="FlowSource{T}"/> — the
+  /// streaming form of a sample list. Mirrors the ADR's
+  /// <c>Samples.Of&lt;T&gt;(...).AsStream()</c> ergonomics.
+  /// </summary>
+  public static FlowSource<T> AsStream<T>(this IEnumerable<T> items) =>
+    FlowSource.FromEnumerable(items);
+}
+
+/// <summary>
+/// A streaming test double: wraps an in-memory sequence in a bracketed
+/// <see cref="FlowSource{T}"/> whose acquire/release and per-item pull are
+/// observable. Lets a streaming test assert that the pull-scoped bracket
+/// released (on every exit path — completion, failure, cancellation) and how
+/// far the read progressed before a mid-stream cancel.
+/// </summary>
+/// <typeparam name="T">The element type produced by the source.</typeparam>
+public sealed class TrackingSource<T>
+{
+  private readonly IEnumerable<T> _items;
+  private readonly Action<int>? _onPulled;
+  private int _acquireCount;
+  private int _releaseCount;
+  private int _pulledCount;
+  private RuntimeError? _lastReleaseError;
+
+  /// <summary>
+  /// Build a tracking source over <paramref name="items"/>.
+  /// </summary>
+  /// <param name="items">The sequence the source yields.</param>
+  /// <param name="onPulled">
+  /// Optional callback invoked with the 1-based index each time an element is
+  /// about to be yielded — the hook a test uses to cancel a
+  /// <see cref="CancellationTokenSource"/> mid-stream and assert the read stops
+  /// and the bracket releases.
+  /// </param>
+  public TrackingSource(IEnumerable<T> items, Action<int>? onPulled = null)
+  {
+    _items = items ?? throw new ArgumentNullException(nameof(items));
+    _onPulled = onPulled;
+  }
+
+  /// <summary>How many times the underlying bracket was acquired (once per compiled run).</summary>
+  public int AcquireCount => _acquireCount;
+
+  /// <summary>How many times the underlying bracket was released.</summary>
+  public int ReleaseCount => _releaseCount;
+
+  /// <summary>How many elements were pulled before the stream ended (or was cancelled/failed).</summary>
+  public int PulledCount => _pulledCount;
+
+  /// <summary>True once the bracket has released at least once.</summary>
+  public bool Released => Volatile.Read(ref _releaseCount) > 0;
+
+  /// <summary>
+  /// The <see cref="RuntimeError"/> the release closure last received —
+  /// <c>null</c> after a clean completion, or the terminating error (e.g.
+  /// <see cref="RuntimeError.Cancelled"/>) after a mid-stream abort.
+  /// </summary>
+  public RuntimeError? LastReleaseError => _lastReleaseError;
+
+  /// <summary>
+  /// The <see cref="FlowSource{T}"/> view. Deferred: acquire runs on the first
+  /// pull of the compiled effect, never at construction.
+  /// </summary>
+  public FlowSource<T> Source =>
+    FlowSource.Bracket(
+      FlowResource.Make<int>(
+        acquire: FlowIO.Lift(() =>
+        {
+          Interlocked.Increment(ref _acquireCount);
+          return 0;
+        }),
+        release: (_, error) => FlowIO.Lift(() =>
+        {
+          Interlocked.Increment(ref _releaseCount);
+          _lastReleaseError = error;
+          return FlowUnit.Default;
+        })
+      ),
+      (_, ct) => Pull(ct)
+    );
+
+  private async IAsyncEnumerable<T> Pull([EnumeratorCancellation] CancellationToken ct)
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    foreach (var item in _items)
+    {
+      ct.ThrowIfCancellationRequested();
+      var index = Interlocked.Increment(ref _pulledCount);
+      _onPulled?.Invoke(index);
+      yield return item;
+    }
+  }
+}
+
+/// <summary>
+/// An observable <see cref="IFlowSink{T}"/> test double. Records the batch
+/// lifecycle (<c>open</c> → <c>write(n)</c>… → <c>complete</c> → <c>dispose</c>)
+/// and every element written, so a streaming test can assert the sink was
+/// completed and released — including the abort path where
+/// <see cref="IFlowSink{T}.CompleteAsync"/> is skipped but
+/// <see cref="System.IAsyncDisposable.DisposeAsync"/> still runs.
+/// </summary>
+/// <typeparam name="T">The element type consumed by the sink.</typeparam>
+public sealed class RecordingSink<T> : IFlowSink<T>
+{
+  private readonly List<string> _events = new();
+  private readonly List<T> _written = new();
+
+  /// <summary>Build a recording sink with the given <paramref name="batchSize"/>.</summary>
+  public RecordingSink(int batchSize = 1) => BatchSize = batchSize;
+
+  /// <summary>The lifecycle trace in order: <c>open</c>, <c>write(n)</c>, <c>complete</c>, <c>dispose</c>.</summary>
+  public IReadOnlyList<string> Events => _events;
+
+  /// <summary>Every element written across all batches.</summary>
+  public IReadOnlyList<T> Written => _written;
+
+  /// <summary>True once <see cref="CompleteAsync"/> ran (the stream drained fully).</summary>
+  public bool Completed { get; private set; }
+
+  /// <summary>True once <see cref="DisposeAsync"/> ran (release happened on some exit path).</summary>
+  public bool Disposed { get; private set; }
+
+  /// <inheritdoc/>
+  public int BatchSize { get; }
+
+  /// <inheritdoc/>
+  public ValueTask OpenAsync(CancellationToken cancellationToken)
+  {
+    _events.Add("open");
+    return ValueTask.CompletedTask;
+  }
+
+  /// <inheritdoc/>
+  public ValueTask WriteBatchAsync(IReadOnlyList<T> batch, CancellationToken cancellationToken)
+  {
+    _events.Add($"write({batch.Count})");
+    _written.AddRange(batch);
+    return ValueTask.CompletedTask;
+  }
+
+  /// <inheritdoc/>
+  public ValueTask CompleteAsync(CancellationToken cancellationToken)
+  {
+    _events.Add("complete");
+    Completed = true;
+    return ValueTask.CompletedTask;
+  }
+
+  /// <inheritdoc/>
+  public ValueTask DisposeAsync()
+  {
+    _events.Add("dispose");
+    Disposed = true;
+    return ValueTask.CompletedTask;
+  }
+}

--- a/src/core/Flowthru.FUnit/SampleBuilder.cs
+++ b/src/core/Flowthru.FUnit/SampleBuilder.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Flowthru.Prelude;
 
 namespace Flowthru.Step.Testing;
 
@@ -13,6 +14,14 @@ public class SampleBuilder
 {
   /// <summary>Wrap explicit instances into an <see cref="IEnumerable{T}"/>.</summary>
   public IEnumerable<T> Of<T>(params T[] items) => items;
+
+  /// <summary>
+  /// Lift explicit instances into a streaming <see cref="FlowSource{T}"/> — the
+  /// streaming counterpart of <see cref="Of{T}"/>. Equivalent to
+  /// <c>Samples.Of(items).AsStream()</c>; provided so a streaming step test can
+  /// build its input as tersely as an eager one.
+  /// </summary>
+  public FlowSource<T> Source<T>(params T[] items) => FlowSource.FromEnumerable(items);
 
   /// <summary>
   /// Generate <paramref name="count"/> rows by invoking

--- a/src/extensions/Flowthru.Extensions.Csv/Data/Storage/Csv/CsvFormatSerializer.cs
+++ b/src/extensions/Flowthru.Extensions.Csv/Data/Storage/Csv/CsvFormatSerializer.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using CsvHelper;
 using CsvHelper.Configuration;
 using Flowthru.Data.Schema;
@@ -93,7 +94,9 @@ public sealed class CsvFormatSerializer<TRow>
   public StorageTraits Traits => new() { CanStream = true };
 
   /// <inheritdoc/>
-  public async IAsyncEnumerable<TRow> DeserializeRows(Stream stream)
+  public async IAsyncEnumerable<TRow> DeserializeRows(
+    Stream stream,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     if (stream is null)
     {
@@ -105,7 +108,7 @@ public sealed class CsvFormatSerializer<TRow>
 
     csv.Context.RegisterClassMap(new SerializedLabelClassMap<TRow>(_nullValues));
 
-    var enumerator = csv.GetRecordsAsync<TRow>().GetAsyncEnumerator();
+    var enumerator = csv.GetRecordsAsync<TRow>(cancellationToken).GetAsyncEnumerator(cancellationToken);
     try
     {
       while (true)

--- a/src/extensions/Flowthru.Extensions.EFCore.Bulk/BulkSink.cs
+++ b/src/extensions/Flowthru.Extensions.EFCore.Bulk/BulkSink.cs
@@ -1,0 +1,66 @@
+using Flowthru.Prelude;
+using Microsoft.EntityFrameworkCore;
+
+namespace Flowthru.Extensions.EFCore.Bulk;
+
+/// <summary>
+/// Factory methods that produce streaming <see cref="IFlowSink{T}"/> writers for
+/// the <c>EFCore.Bulk</c> extension — the sink counterpart to the eager
+/// <see cref="BulkSave"/> delegates. A sink is the terminal of a
+/// <see cref="FlowSource{A}"/> bulk-load
+/// (<c>source.Compile().Into(BulkSink.Insert&lt;T, TContext&gt;(factory))</c>),
+/// writing one batch per <c>BulkInsertAsync</c> inside a single transaction so
+/// the load is O(batch) in memory and all-or-nothing on failure.
+/// </summary>
+/// <example>
+/// <code>
+/// var sink = BulkSink.Insert&lt;MyEntity, MyDbContext&gt;(_factory);
+/// await source.Compile().Into(sink).Run();
+/// </code>
+/// </example>
+public static class BulkSink
+{
+  /// <summary>
+  /// Bulk-insert a stream into the target table one batch at a time inside a
+  /// single transaction. Does not modify or remove existing data. Mirrors
+  /// <see cref="BulkSave.Insert{T, TContext}"/> for the streaming path.
+  /// </summary>
+  /// <typeparam name="T">The entity type.</typeparam>
+  /// <typeparam name="TContext">The DbContext type.</typeparam>
+  /// <param name="contextFactory">
+  /// EF Core context factory; a fresh context is created when the sink opens and
+  /// disposed when it is disposed — the concurrent-pipeline pattern.
+  /// </param>
+  /// <param name="options">Optional bulk operation configuration.</param>
+  /// <returns>An <see cref="IFlowSink{T}"/> to pass to <see cref="FlowSourceCompiler{A}.Into"/>.</returns>
+  public static IFlowSink<T> Insert<T, TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    BulkSaveOptions? options = null
+  )
+    where T : class
+    where TContext : DbContext
+  {
+    ArgumentNullException.ThrowIfNull(contextFactory);
+    return new EFCoreBulkSink<T, TContext>(() => contextFactory.CreateDbContext(), options);
+  }
+
+  /// <summary>
+  /// Bulk-insert a stream into the target table using a typed factory delegate.
+  /// Useful when constructing contexts manually or in tests.
+  /// </summary>
+  /// <typeparam name="T">The entity type.</typeparam>
+  /// <typeparam name="TContext">The DbContext type.</typeparam>
+  /// <param name="contextFactory">Delegate producing a fresh DbContext when the sink opens.</param>
+  /// <param name="options">Optional bulk operation configuration.</param>
+  /// <returns>An <see cref="IFlowSink{T}"/> to pass to <see cref="FlowSourceCompiler{A}.Into"/>.</returns>
+  public static IFlowSink<T> Insert<T, TContext>(
+    Func<TContext> contextFactory,
+    BulkSaveOptions? options = null
+  )
+    where T : class
+    where TContext : DbContext
+  {
+    ArgumentNullException.ThrowIfNull(contextFactory);
+    return new EFCoreBulkSink<T, TContext>(contextFactory, options);
+  }
+}

--- a/src/extensions/Flowthru.Extensions.EFCore.Bulk/EFCoreBulkSink.cs
+++ b/src/extensions/Flowthru.Extensions.EFCore.Bulk/EFCoreBulkSink.cs
@@ -1,0 +1,160 @@
+using EFCore.BulkExtensions;
+using Flowthru.Extensions.EFCore.Bulk.Internal;
+using Flowthru.Prelude;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Flowthru.Extensions.EFCore.Bulk;
+
+/// <summary>
+/// A streaming <see cref="IFlowSink{T}"/> that bulk-inserts a
+/// <see cref="FlowSource{A}"/> into an EF Core table <em>one batch at a time,
+/// inside a single transaction</em>. Driven by
+/// <see cref="FlowSourceCompiler{A}.Into"/>: a context + transaction open once
+/// (<see cref="OpenAsync"/>), each arriving batch issues its own
+/// <c>BulkInsertAsync</c> enlisted in that transaction
+/// (<see cref="WriteBatchAsync"/>), and the transaction commits on success
+/// (<see cref="CompleteAsync"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why per-batch.</strong> The eager <see cref="BulkSave"/> path makes a
+/// single <c>BulkInsertAsync</c> over the whole dataset; handing that call a lazy
+/// <see cref="IEnumerable{T}"/> re-materialises it internally (O(dataset)),
+/// defeating the memory win. This sink instead consumes the driver's
+/// <see cref="BatchSize"/>-sized batches, so peak memory is O(batch) end-to-end.
+/// </para>
+/// <para>
+/// <strong>Why one transaction.</strong> <c>EFCore.BulkExtensions</c> enlists in
+/// the context's ambient transaction, so every batch lands in the transaction
+/// opened at <see cref="OpenAsync"/>. If the stream fails partway,
+/// <see cref="DisposeAsync"/> runs without <see cref="CompleteAsync"/> having been
+/// reached and rolls the whole write back — no corrupt-but-present table — keeping
+/// the adapter's <c>IsTransactional</c> claim honest.
+/// </para>
+/// <para>
+/// <strong>Ownership.</strong> The sink owns the context and transaction it
+/// creates and disposes both on every exit path. Batches passed to
+/// <see cref="WriteBatchAsync"/> are consumed synchronously within the call and
+/// never retained, so the driver is free to reuse its buffer.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The entity type.</typeparam>
+/// <typeparam name="TContext">The DbContext type.</typeparam>
+public sealed class EFCoreBulkSink<T, TContext> : IFlowSink<T>
+  where T : class
+  where TContext : DbContext
+{
+  private readonly Func<TContext> _contextFactory;
+  private readonly BulkSaveOptions _options;
+  private readonly BulkConfig _config;
+
+  private TContext? _context;
+  private IDbContextTransaction? _transaction;
+  private bool _completed;
+  private int _batchesWritten;
+
+  /// <summary>
+  /// Create a sink over a typed context factory. A fresh context is created at
+  /// <see cref="OpenAsync"/> and disposed at <see cref="DisposeAsync"/>.
+  /// </summary>
+  /// <param name="contextFactory">Factory producing a DbContext for the write.</param>
+  /// <param name="options">Optional bulk operation configuration.</param>
+  public EFCoreBulkSink(Func<TContext> contextFactory, BulkSaveOptions? options = null)
+  {
+    _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+    _options = options ?? new BulkSaveOptions();
+    _config = BulkConfigMapper.ToBulkConfig(_options);
+  }
+
+  /// <inheritdoc/>
+  /// <remarks>Sourced from <see cref="BulkSaveOptions.BatchSize"/> (default 2000).</remarks>
+  public int BatchSize => _options.BatchSize;
+
+  /// <summary>
+  /// Number of <see cref="WriteBatchAsync"/> calls that have run — a test/
+  /// observability hook proving the write is incremental (per-batch) rather than
+  /// one materialised bulk call.
+  /// </summary>
+  internal int BatchesWritten => _batchesWritten;
+
+  /// <inheritdoc/>
+  public async ValueTask OpenAsync(CancellationToken cancellationToken)
+  {
+    if (_context is not null)
+      throw new InvalidOperationException("EFCoreBulkSink is already open.");
+
+    _context = _contextFactory();
+
+    // The bulk operations below enlist in this ambient transaction; committing
+    // here is the sole path that persists the write (Dispose-without-Complete
+    // rolls back).
+    _transaction = await _context
+      .Database.BeginTransactionAsync(cancellationToken)
+      .ConfigureAwait(false);
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask WriteBatchAsync(
+    IReadOnlyList<T> batch,
+    CancellationToken cancellationToken
+  )
+  {
+    if (_context is null)
+      throw new InvalidOperationException("EFCoreBulkSink.WriteBatchAsync called before OpenAsync.");
+
+    // The batch is valid only for this call; BulkInsertAsync consumes it
+    // synchronously, so no copy is needed.
+    await _context
+      .BulkInsertAsync(
+        batch,
+        _config,
+        progress: _options.OnProgress,
+        cancellationToken: cancellationToken
+      )
+      .ConfigureAwait(false);
+
+    _batchesWritten++;
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask CompleteAsync(CancellationToken cancellationToken)
+  {
+    if (_transaction is null)
+      throw new InvalidOperationException("EFCoreBulkSink.CompleteAsync called before OpenAsync.");
+
+    await _transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+    _completed = true;
+  }
+
+  /// <inheritdoc/>
+  public async ValueTask DisposeAsync()
+  {
+    if (_transaction is not null)
+    {
+      // Reached only when CompleteAsync did not commit — abort the whole write.
+      // Roll back uncancellably: the reason we are disposing is often that the
+      // ambient token was cancelled, and the rollback must still run.
+      if (!_completed)
+      {
+        try
+        {
+          await _transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch
+        {
+          // Best-effort: the transaction may already be aborted by the provider.
+        }
+      }
+
+      await _transaction.DisposeAsync().ConfigureAwait(false);
+      _transaction = null;
+    }
+
+    if (_context is not null)
+    {
+      await _context.DisposeAsync().ConfigureAwait(false);
+      _context = null;
+    }
+  }
+}

--- a/src/extensions/Flowthru.Extensions.Excel/Data/Storage/Excel/ExcelFormatSerializer.cs
+++ b/src/extensions/Flowthru.Extensions.Excel/Data/Storage/Excel/ExcelFormatSerializer.cs
@@ -90,14 +90,12 @@ public sealed class ExcelFormatSerializer<TRow>
       throw new ArgumentNullException(nameof(stream));
     }
 
-    // ExcelDataReader requires a seekable stream; buffer if needed.
-    if (!stream.CanSeek)
-    {
-      var buffered = new MemoryStream();
-      await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
-      buffered.Position = 0;
-      stream = buffered;
-    }
+    // ExcelDataReader requires a seekable stream; SeekableSpill makes a
+    // forward-only source seekable by spilling to a bounded temp file rather
+    // than buffering the whole workbook in RAM. An already-seekable source
+    // passes through untouched.
+    await using var spill = await SeekableSpill.CreateAsync(stream, cancellationToken).ConfigureAwait(false);
+    stream = spill.Stream;
 
     Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 

--- a/src/extensions/Flowthru.Extensions.Excel/Data/Storage/Excel/ExcelFormatSerializer.cs
+++ b/src/extensions/Flowthru.Extensions.Excel/Data/Storage/Excel/ExcelFormatSerializer.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Text;
 using ExcelDataReader;
 using Flowthru.Data.Schema;
@@ -80,7 +81,9 @@ public sealed class ExcelFormatSerializer<TRow>
   public StorageTraits Traits => new() { CanWrite = false, CanStream = false };
 
   /// <inheritdoc/>
-  public async IAsyncEnumerable<TRow> DeserializeRows(Stream stream)
+  public async IAsyncEnumerable<TRow> DeserializeRows(
+    Stream stream,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     if (stream is null)
     {
@@ -91,7 +94,7 @@ public sealed class ExcelFormatSerializer<TRow>
     if (!stream.CanSeek)
     {
       var buffered = new MemoryStream();
-      await stream.CopyToAsync(buffered).ConfigureAwait(false);
+      await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
       buffered.Position = 0;
       stream = buffered;
     }
@@ -127,6 +130,7 @@ public sealed class ExcelFormatSerializer<TRow>
 
       while (reader.Read())
       {
+        cancellationToken.ThrowIfCancellationRequested();
         var row = SchemaActivator.CreateInstance<TRow>();
         foreach (var binding in plan.Bindings)
         {

--- a/src/extensions/Flowthru.Extensions.Parquet/Data/Storage/Parquet/ParquetFormatSerializer.cs
+++ b/src/extensions/Flowthru.Extensions.Parquet/Data/Storage/Parquet/ParquetFormatSerializer.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Flowthru.Data.Schema;
 using Flowthru.Data.Schema.Mapping;
 using Flowthru.Data.Storage.Parquet.Internal;
@@ -75,7 +76,9 @@ public sealed class ParquetFormatSerializer<TRow>
   public StorageTraits Traits => new() { CanStream = true };
 
   /// <inheritdoc/>
-  public async IAsyncEnumerable<TRow> DeserializeRows(Stream stream)
+  public async IAsyncEnumerable<TRow> DeserializeRows(
+    Stream stream,
+    [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     if (stream is null)
     {
@@ -93,7 +96,7 @@ public sealed class ParquetFormatSerializer<TRow>
     if (!stream.CanSeek)
     {
       buffered = new MemoryStream();
-      await stream.CopyToAsync(buffered).ConfigureAwait(false);
+      await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
       buffered.Position = 0;
       stream = buffered;
     }
@@ -102,7 +105,8 @@ public sealed class ParquetFormatSerializer<TRow>
     {
       var readOptions = _options?.ToReadOptions();
 
-      using var reader = await ParquetReader.CreateAsync(stream, leaveStreamOpen: true)
+      using var reader = await ParquetReader
+        .CreateAsync(stream, leaveStreamOpen: true, cancellationToken: cancellationToken)
         .ConfigureAwait(false);
       var schema = reader.Schema;
       var rowGroupCount = reader.RowGroupCount;
@@ -134,6 +138,7 @@ public sealed class ParquetFormatSerializer<TRow>
       // inspection, small-sample readers) avoid full-file materialisation.
       for (var rgi = 0; rgi < rowGroupCount; rgi++)
       {
+        cancellationToken.ThrowIfCancellationRequested();
         stream.Position = 0;
         var dtos = await adapter.DeserializeRowGroup(stream, rgi, readOptions).ConfigureAwait(false);
         foreach (var dto in dtos)

--- a/src/extensions/Flowthru.Extensions.Parquet/Data/Storage/Parquet/ParquetFormatSerializer.cs
+++ b/src/extensions/Flowthru.Extensions.Parquet/Data/Storage/Parquet/ParquetFormatSerializer.cs
@@ -88,72 +88,57 @@ public sealed class ParquetFormatSerializer<TRow>
     // Parquet decoding requires random access: ParquetReader reads the footer
     // at the end of the object first, and each row group is re-read from a reset
     // position below. A forward-only source — a real S3 or HTTP response body —
-    // reports CanSeek == false, so materialise it into a seekable MemoryStream
-    // before decoding. Mirrors the guard in ExcelFormatSerializer. This does not
-    // contradict Traits.CanStream: streaming describes incremental row-group
-    // *consumption*, not seekability of the underlying byte source.
-    MemoryStream? buffered = null;
-    if (!stream.CanSeek)
+    // reports CanSeek == false; SeekableSpill makes it seekable by spilling to a
+    // bounded temp file (O(object) disk, not O(object) RAM), so peak read memory
+    // stays at one row group regardless of object size. An already-seekable
+    // source passes through untouched. This does not contradict Traits.CanStream:
+    // streaming describes incremental row-group *consumption*, not seekability of
+    // the underlying byte source.
+    await using var spill = await SeekableSpill.CreateAsync(stream, cancellationToken).ConfigureAwait(false);
+    var seekable = spill.Stream;
+
+    var readOptions = _options?.ToReadOptions();
+
+    using var reader = await ParquetReader
+      .CreateAsync(seekable, leaveStreamOpen: true, cancellationToken: cancellationToken)
+      .ConfigureAwait(false);
+    var schema = reader.Schema;
+    var rowGroupCount = reader.RowGroupCount;
+
+    // Pre-flight schema check: every column the schema declares must
+    // be present in the on-disk file. Without this, missing columns
+    // silently deserialize to default values and pre-flight passes on
+    // a structurally invalid file. We standardise on
+    // SchemaMismatchException across all formats so the composed
+    // adapter classifies them uniformly.
+    var expectedColumns = PropertyMappingPlanner.Build<TRow>().ByFieldName.Keys;
+    var fileColumns = new HashSet<string>(
+      schema.Fields.OfType<DataField>().Select(f => f.Name),
+      StringComparer.OrdinalIgnoreCase
+    );
+    var missing = expectedColumns.Where(c => !fileColumns.Contains(c)).ToList();
+    if (missing.Count > 0)
     {
-      buffered = new MemoryStream();
-      await stream.CopyToAsync(buffered, cancellationToken).ConfigureAwait(false);
-      buffered.Position = 0;
-      stream = buffered;
-    }
-
-    try
-    {
-      var readOptions = _options?.ToReadOptions();
-
-      using var reader = await ParquetReader
-        .CreateAsync(stream, leaveStreamOpen: true, cancellationToken: cancellationToken)
-        .ConfigureAwait(false);
-      var schema = reader.Schema;
-      var rowGroupCount = reader.RowGroupCount;
-
-      // Pre-flight schema check: every column the schema declares must
-      // be present in the on-disk file. Without this, missing columns
-      // silently deserialize to default values and pre-flight passes on
-      // a structurally invalid file. We standardise on
-      // SchemaMismatchException across all formats so the composed
-      // adapter classifies them uniformly.
-      var expectedColumns = PropertyMappingPlanner.Build<TRow>().ByFieldName.Keys;
-      var fileColumns = new HashSet<string>(
-        schema.Fields.OfType<DataField>().Select(f => f.Name),
-        StringComparer.OrdinalIgnoreCase
+      throw new SchemaMismatchException(
+        $"Parquet file is missing column(s) declared by schema '{typeof(TRow).Name}': "
+        + $"[{string.Join(", ", missing)}]. "
+        + $"File columns: [{string.Join(", ", fileColumns)}]."
       );
-      var missing = expectedColumns.Where(c => !fileColumns.Contains(c)).ToList();
-      if (missing.Count > 0)
-      {
-        throw new SchemaMismatchException(
-          $"Parquet file is missing column(s) declared by schema '{typeof(TRow).Name}': "
-          + $"[{string.Join(", ", missing)}]. "
-          + $"File columns: [{string.Join(", ", fileColumns)}]."
-        );
-      }
-
-      var adapter = new ParquetAdapter<TRow>(schema);
-
-      // Yield one row group at a time so early-break consumers (shallow
-      // inspection, small-sample readers) avoid full-file materialisation.
-      for (var rgi = 0; rgi < rowGroupCount; rgi++)
-      {
-        cancellationToken.ThrowIfCancellationRequested();
-        stream.Position = 0;
-        var dtos = await adapter.DeserializeRowGroup(stream, rgi, readOptions).ConfigureAwait(false);
-        foreach (var dto in dtos)
-        {
-          yield return adapter.FromDto(dto);
-        }
-      }
     }
-    finally
+
+    var adapter = new ParquetAdapter<TRow>(schema);
+
+    // Yield one row group at a time so early-break consumers (shallow
+    // inspection, small-sample readers) avoid full-file materialisation.
+    for (var rgi = 0; rgi < rowGroupCount; rgi++)
     {
-      // We opened the reader with leaveStreamOpen: true, so the buffer we
-      // allocated here is ours to dispose once enumeration completes or is
-      // abandoned. (When the caller's stream was already seekable, buffered is
-      // null and this is a no-op — we never own the caller's stream.)
-      buffered?.Dispose();
+      cancellationToken.ThrowIfCancellationRequested();
+      seekable.Position = 0;
+      var dtos = await adapter.DeserializeRowGroup(seekable, rgi, readOptions).ConfigureAwait(false);
+      foreach (var dto in dtos)
+      {
+        yield return adapter.FromDto(dto);
+      }
     }
   }
 

--- a/src/extensions/Flowthru.Extensions.Python/Step/Python/PythonStepExtension.cs
+++ b/src/extensions/Flowthru.Extensions.Python/Step/Python/PythonStepExtension.cs
@@ -27,11 +27,14 @@ namespace Flowthru.Step.Python;
 /// behaviour. The attribute drives <c>FT1301</c> (minimum-coverage
 /// floor) and <c>FT1303</c> (capability/marshaller alignment); the
 /// marker interface is the implementation evidence that
-/// <c>FT1303</c> verifies. <c>IQueryableMarshaller</c> and
-/// <c>IAsyncStreamMarshaller</c> are intentionally absent — the
-/// Python subprocess executor does not push computation down into
-/// the data source nor stream rows lazily, so declaring those kinds
-/// would be a false claim.
+/// <c>FT1303</c> verifies. <c>IQueryableMarshaller</c> is
+/// intentionally absent — the Python subprocess executor does not
+/// push computation down into the data source, so declaring
+/// <see cref="StepContainerKind.Queryable"/> would be a false claim.
+/// Streaming (<see cref="StepContainerKind.Source"/>) has no marker:
+/// per ADR-0023 the eager <see cref="StepContainerKind.Enumerable"/>
+/// path already covers what a step consumes, and Arrow marshalling
+/// materialises the batch today (chunk-wise streaming is a follow-up).
 /// </para>
 /// </remarks>
 [StepExtensionCapabilities(

--- a/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1201StreamingTraitHonestyTests.cs
+++ b/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1201StreamingTraitHonestyTests.cs
@@ -1,0 +1,313 @@
+using Flowthru.Core.SourceGenerators.Storage;
+
+namespace Flowthru.Core.SourceGenerators.Tests;
+
+/// <summary>
+/// Tests for <see cref="StreamingTraitHonestyAnalyzer"/> — the <c>FT1201</c>
+/// analyzer that enforces "declared <c>StorageTraits.CanStream = true</c> ⇒ the
+/// format actually streams". Covers both sub-cases (the missing
+/// <c>IFormatStreamReader&lt;TRow&gt;</c> marker, and a <c>DeserializeRows</c>
+/// body that materialises the whole input) and the low-false-positive guards
+/// (honest streaming readers, bounded metadata <c>ToList</c>, non-format types).
+/// </summary>
+[TestFixture]
+public class Ft1201StreamingTraitHonestyTests
+{
+  // ── Stubs ─────────────────────────────────────────────────────────────
+  //
+  // Minimal stand-ins for the storage surface. The analyzer gates on the
+  // IFormatRowReader<TRow>/IFormatStreamReader<TRow> interfaces by
+  // fully-qualified name, reads CanStream from an object-initializer literal,
+  // and scans DeserializeRows syntactically — so the stubs need no real
+  // System.Text.Json / async-stream machinery.
+
+  private const string Stubs = """
+    namespace Flowthru.Data.Storage
+    {
+      public record StorageTraits
+      {
+        public bool CanStream { get; init; }
+      }
+
+      public interface IFormatRowReader<TRow>
+      {
+        StorageTraits Traits { get; }
+      }
+
+      public interface IFormatStreamReader<TRow> : IFormatRowReader<TRow> { }
+    }
+
+    namespace Sample
+    {
+      // Trailing-name match is all the analyzer needs for the JSON branch, so a
+      // local stub named JsonSerializer stands in for System.Text.Json's.
+      public static class JsonSerializer
+      {
+        public static System.Collections.Generic.IEnumerable<T> Deserialize<T>(System.IO.Stream s) =>
+          System.Linq.Enumerable.Empty<T>();
+        public static System.Collections.Generic.IEnumerable<T> DeserializeAsyncEnumerable<T>(System.IO.Stream s) =>
+          System.Linq.Enumerable.Empty<T>();
+      }
+
+      public record Row(int Id);
+    }
+    """;
+
+  // ── Honest streaming reader is silent ────────────────────────────────
+
+  [Test]
+  public async Task StreamingReader_YieldingIncrementally_Silent()
+  {
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class HonestJsonSerializer : IFormatStreamReader<Row>
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          foreach (var r in JsonSerializer.DeserializeAsyncEnumerable<Row>(stream))
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+    Assert.That(diags.Where("FT1201").ToList(), Is.Empty,
+      "An honest streaming reader (marker + incremental yield) must not fire FT1201.");
+  }
+
+  // ── Marker honesty branch ────────────────────────────────────────────
+
+  [Test]
+  public async Task CanStreamTrue_WithoutStreamReaderMarker_FiresFt1201()
+  {
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class MarkerlessSerializer : IFormatRowReader<Row>
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          foreach (var r in JsonSerializer.DeserializeAsyncEnumerable<Row>(stream))
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+
+    var ft1201 = diags.Where("FT1201").ToList();
+    Assert.That(ft1201, Is.Not.Empty);
+    Assert.That(ft1201[0].GetMessage(), Does.Contain("IFormatStreamReader"));
+  }
+
+  // ── Body honesty branch: whole-document JSON ─────────────────────────
+
+  [Test]
+  public async Task DeserializeRows_UsesWholeDocumentJsonDeserialize_FiresFt1201()
+  {
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class BufferingJsonSerializer : IFormatStreamReader<Row>
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          // Dishonest: buffers the entire document, then yields.
+          var all = JsonSerializer.Deserialize<Row>(stream);
+          foreach (var r in all)
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+
+    var ft1201 = diags.Where("FT1201").ToList();
+    Assert.That(ft1201, Is.Not.Empty);
+    Assert.That(ft1201[0].GetMessage(), Does.Contain("JsonSerializer.Deserialize"));
+  }
+
+  // ── Body honesty branch: ToList over the input stream ────────────────
+
+  [Test]
+  public async Task DeserializeRows_MaterialisesInputStreamWithToList_FiresFt1201()
+  {
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using System.Linq;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class ToListSerializer : IFormatStreamReader<Row>
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          // Dishonest: drains the whole stream-derived enumerable into a List.
+          var all = JsonSerializer.DeserializeAsyncEnumerable<Row>(stream).ToList();
+          foreach (var r in all)
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+
+    var ft1201 = diags.Where("FT1201").ToList();
+    Assert.That(ft1201, Is.Not.Empty);
+    Assert.That(ft1201[0].GetMessage(), Does.Contain("ToList"));
+  }
+
+  // ── Low-false-positive guard: bounded ToList over metadata (Parquet shape) ──
+
+  [Test]
+  public async Task DeserializeRows_ToListOverMetadataNotStream_Silent()
+  {
+    // Mirrors ParquetFormatSerializer: a `.ToList()` over a small column-name
+    // set (never the input stream). Must NOT fire — a false positive here would
+    // break the Parquet build.
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using System.Linq;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class RowGroupSerializer : IFormatStreamReader<Row>
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          var expected = new[] { "a", "b", "c" };
+          var present = new HashSet<string> { "a", "b" };
+          var missing = expected.Where(c => !present.Contains(c)).ToList();
+          foreach (var r in JsonSerializer.DeserializeAsyncEnumerable<Row>(stream))
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+    Assert.That(diags.Where("FT1201").ToList(), Is.Empty,
+      "A bounded ToList over metadata (not the input stream) must not fire FT1201.");
+  }
+
+  // ── CanStream not declared: body is not policed ──────────────────────
+
+  [Test]
+  public async Task BufferingBody_WithoutCanStream_Silent()
+  {
+    var consumer = """
+      using System.Collections.Generic;
+      using System.IO;
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class HonestlyBufferedSerializer : IFormatRowReader<Row>
+      {
+        // CanStream defaults to false — buffering is legitimate.
+        public StorageTraits Traits => new();
+
+        public IEnumerable<Row> DeserializeRows(Stream stream)
+        {
+          var all = JsonSerializer.Deserialize<Row>(stream);
+          foreach (var r in all)
+          {
+            yield return r;
+          }
+        }
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+    Assert.That(diags.Where("FT1201").ToList(), Is.Empty,
+      "A buffering reader that honestly leaves CanStream = false must not fire FT1201.");
+  }
+
+  // ── Non-format types are out of scope ────────────────────────────────
+
+  [Test]
+  public async Task NonFormatTypeWithCanStream_Silent()
+  {
+    // Represents a storage adapter/medium (EFCore, S3) that carries CanStream on
+    // its own traits but is not an IFormatRowReader — out of the analyzer's scope.
+    var consumer = """
+      using Flowthru.Data.Storage;
+
+      namespace Sample;
+
+      public sealed class BulkAdapter
+      {
+        public StorageTraits Traits => new() { CanStream = true };
+      }
+      """;
+
+    var diags = await AnalyzerTestHarness.RunAsync(
+      new StreamingTraitHonestyAnalyzer(),
+      new[] { Stubs, consumer }
+    );
+    Assert.That(diags.Where("FT1201").ToList(), Is.Empty,
+      "A non-IFormatRowReader type must not fire FT1201 even with CanStream = true.");
+  }
+
+  [Test]
+  public void SupportedDiagnostics_ExposesFt1201()
+  {
+    var analyzer = new StreamingTraitHonestyAnalyzer();
+    Assert.That(analyzer.SupportedDiagnostics.Select(d => d.Id),
+      Has.Member("FT1201"));
+  }
+}

--- a/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1301ExtensionMinimumContainerSupportTests.cs
+++ b/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1301ExtensionMinimumContainerSupportTests.cs
@@ -31,7 +31,7 @@ public class Ft1301ExtensionMinimumContainerSupportTests
         Singleton = 1,
         Enumerable = 2,
         Queryable = 4,
-        AsyncStream = 8,
+        Source = 8,
       }
 
       public enum ExtensionStatus

--- a/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1303ExtensionCapabilityMarshallerAlignmentTests.cs
+++ b/tests/core/Flowthru.Core.SourceGenerators.Tests/Ft1303ExtensionCapabilityMarshallerAlignmentTests.cs
@@ -25,7 +25,7 @@ public class Ft1303ExtensionCapabilityMarshallerAlignmentTests
         Singleton = 1,
         Enumerable = 2,
         Queryable = 4,
-        AsyncStream = 8,
+        Source = 8,
       }
 
       public enum ExtensionStatus
@@ -52,7 +52,6 @@ public class Ft1303ExtensionCapabilityMarshallerAlignmentTests
     {
       public interface IContainerMarshaller<TExtension> where TExtension : Flowthru.Step.IStepExtension { }
       public interface IQueryableMarshaller<TExtension> where TExtension : Flowthru.Step.IStepExtension { }
-      public interface IAsyncStreamMarshaller<TExtension> where TExtension : Flowthru.Step.IStepExtension { }
     }
     """;
 
@@ -223,11 +222,15 @@ public class Ft1303ExtensionCapabilityMarshallerAlignmentTests
     Assert.That(ft1303[0].GetMessage(), Does.Contain("does not declare Queryable"));
   }
 
-  // ── AsyncStream alignment ────────────────────────────────────────────
+  // ── Source: no marshaller marker, so no alignment check ──────────────
 
   [Test]
-  public async Task AsyncStreamDeclared_WithoutMarshaller_FiresFt1303()
+  public async Task SourceDeclared_WithoutMarshaller_Silent()
   {
+    // StepContainerKind.Source (a FlowSource<T> streaming payload) has no
+    // marshaller marker — per ADR-0023 a FlowSource is consumed by
+    // compiling back into FlowIO, not marshalled across a marker seam —
+    // so declaring it never fires an alignment diagnostic.
     var consumer = """
       using Flowthru.Step;
       using Flowthru.Step.Marshalling;
@@ -235,11 +238,11 @@ public class Ft1303ExtensionCapabilityMarshallerAlignmentTests
       namespace Sample;
 
       [StepExtensionCapabilities(
-        StepContainerKind.Singleton | StepContainerKind.Enumerable | StepContainerKind.AsyncStream,
+        StepContainerKind.Singleton | StepContainerKind.Enumerable | StepContainerKind.Source,
         StepContainerKind.Singleton | StepContainerKind.Enumerable)]
-      public sealed class HalfAsyncExtension :
+      public sealed class SourceExtension :
         IStepExtension,
-        IContainerMarshaller<HalfAsyncExtension>
+        IContainerMarshaller<SourceExtension>
       { }
       """;
 
@@ -247,10 +250,7 @@ public class Ft1303ExtensionCapabilityMarshallerAlignmentTests
       new ExtensionCapabilityMarshallerAlignmentAnalyzer(),
       new[] { Stubs, consumer }
     );
-
-    var ft1303 = diags.Where("FT1303").ToList();
-    Assert.That(ft1303, Is.Not.Empty);
-    Assert.That(ft1303[0].GetMessage(), Does.Contain("IAsyncStreamMarshaller"));
+    Assert.That(diags.Where("FT1303").ToList(), Is.Empty);
   }
 
   // ── Non-extension classes are silent ─────────────────────────────────

--- a/tests/core/Flowthru.Core.Tests/Catalog/AsStreamTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Catalog/AsStreamTests.cs
@@ -1,0 +1,220 @@
+using System.Runtime.CompilerServices;
+using Flowthru.Data.Catalog;
+using Flowthru.Data.Storage;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Core.Tests.Catalog;
+
+/// <summary>
+/// Tests for the <c>.AsStream()</c> catalog view (#116): the deferred
+/// streaming <c>Load()</c>, the capability gate, schema-mismatch translation,
+/// fan-out re-acquisition, and read-only semantics.
+/// </summary>
+[TestFixture]
+public class AsStreamTests
+{
+  [Test]
+  public async Task AsStream_LoadThenCompile_YieldsRows()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1, 2, 3 });
+
+    var source = await LoadSource(item.AsStream());
+    var rows = await source.Compile().ToList().Run();
+
+    Assert.That(((EffResult<IReadOnlyList<int>>.Success)rows).Value, Is.EqualTo(new[] { 1, 2, 3 }));
+  }
+
+  [Test]
+  public async Task AsStream_Load_DoesNotOpenMedium_UntilCompiledAndRun()
+  {
+    var medium = new StubMedium();
+    var item = StreamingSource(medium, new[] { 1, 2 }).AsStream();
+
+    var source = await LoadSource(item);
+    Assert.That(medium.ReadStreamCalls, Is.EqualTo(0), "Load returns a description; nothing opens yet.");
+
+    await source.Compile().Drain().Run();
+    Assert.That(medium.ReadStreamCalls, Is.EqualTo(1));
+  }
+
+  [Test]
+  public async Task AsStream_FanOut_ReAcquiresPerCompile()
+  {
+    var medium = new StubMedium();
+    var source = await LoadSource(StreamingSource(medium, new[] { 1, 2 }).AsStream());
+
+    await source.Compile().Drain().Run();
+    await source.Compile().Drain().Run();
+
+    Assert.That(medium.ReadStreamCalls, Is.EqualTo(2), "Each consumer re-acquires the source.");
+  }
+
+  [Test]
+  public async Task AsStream_MediumStream_IsDisposedAfterRun()
+  {
+    var medium = new StubMedium();
+    var source = await LoadSource(StreamingSource(medium, new[] { 1, 2 }).AsStream());
+
+    await source.Compile().Drain().Run();
+
+    Assert.That(medium.Opened.Single().Disposed, Is.True);
+  }
+
+  [Test]
+  public async Task AsStream_SchemaMismatch_SurfacesAsTypedRuntimeError()
+  {
+    var source = await LoadSource(
+      StreamingSource(new StubMedium(), Array.Empty<int>(), throwSchemaMismatch: true).AsStream()
+    );
+
+    var result = await source.Compile().ToList().Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
+    Assert.That(
+      ((EffResult<IReadOnlyList<int>>.Failure)result).Error,
+      Is.InstanceOf<RuntimeError.SchemaMismatch>(),
+      "The storage layer must translate SchemaMismatchException to the typed variant, not External."
+    );
+  }
+
+  [Test]
+  public void AsStream_OnNonStreamingFormat_ThrowsAtWireUp()
+  {
+    var adapter = new ComposedStorageAdapter<IEnumerable<int>, int>(
+      new StubMedium(),
+      new StubNonStreamingReader<int>(),
+      writer: null,
+      new EnumerableContainerAdapter<int>()
+    );
+    var item = new Item<IEnumerable<int>>("non-streaming", adapter);
+
+    Assert.Throws<ArgumentException>(() => item.AsStream());
+  }
+
+  [Test]
+  public async Task AsStream_Item_IsReadOnly_SaveFails()
+  {
+    var streaming = StreamingSource(new StubMedium(), new[] { 1 }).AsStream();
+
+    var result = await streaming.Save(FlowSource.Empty<int>()).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+  }
+
+  [Test]
+  public void AsStream_AfterConstrain_UnwrapsToTheComposedFormat()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1 })
+      .Constrain(t => t with { CanWrite = false });
+
+    // Does not throw — the .Constrain() wrapper is unwrapped to the composed format.
+    Assert.DoesNotThrow(() => item.AsStream());
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private static IItem<IEnumerable<int>> StreamingSource(
+    StubMedium medium,
+    IReadOnlyList<int> rows,
+    bool throwSchemaMismatch = false
+  )
+  {
+    var adapter = new ComposedStorageAdapter<IEnumerable<int>, int>(
+      medium,
+      new StubStreamingReader<int>(rows, throwSchemaMismatch),
+      writer: null,
+      new EnumerableContainerAdapter<int>()
+    );
+    return new Item<IEnumerable<int>>("stream-test", adapter);
+  }
+
+  private static async Task<FlowSource<int>> LoadSource(IReadOnlyItem<FlowSource<int>> item)
+  {
+    var result = await item.Load().Run();
+    return ((EffResult<FlowSource<int>>.Success)result).Value;
+  }
+
+  private sealed class TrackingStream : MemoryStream
+  {
+    public bool Disposed { get; private set; }
+
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing) Disposed = true;
+      base.Dispose(disposing);
+    }
+  }
+
+  private sealed class StubMedium : IStorageMedium
+  {
+    public int ReadStreamCalls { get; private set; }
+    public List<TrackingStream> Opened { get; } = new();
+
+    public StorageTraits Traits => new() { CanStream = true };
+
+    public FlowIO<Stream> ReadStream() =>
+      FlowIO.Lift<Stream>(() =>
+      {
+        ReadStreamCalls++;
+        var stream = new TrackingStream();
+        Opened.Add(stream);
+        return stream;
+      });
+
+    public FlowIO<FlowUnit> WriteStream(Stream stream) =>
+      FlowIO.Fail<FlowUnit>(new RuntimeError.External("StubMedium", new NotSupportedException()));
+
+    public FlowIO<bool> Exists() => FlowIO.Pure(true);
+  }
+
+  private sealed class StubStreamingReader<TRow>
+    : IFormatRowReader<TRow>, IFormatStreamReader<TRow>
+    where TRow : notnull
+  {
+    private readonly IReadOnlyList<TRow> _rows;
+    private readonly bool _throwSchemaMismatch;
+
+    public StubStreamingReader(IReadOnlyList<TRow> rows, bool throwSchemaMismatch)
+    {
+      _rows = rows;
+      _throwSchemaMismatch = throwSchemaMismatch;
+    }
+
+    public StorageTraits Traits => new() { CanStream = true };
+
+    public async IAsyncEnumerable<TRow> DeserializeRows(
+      Stream stream,
+      [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      await Task.CompletedTask.ConfigureAwait(false);
+      if (_throwSchemaMismatch)
+      {
+        throw new SchemaMismatchException(
+          "missing column 'x'",
+          new InvalidOperationException("provider detail")
+        );
+      }
+
+      foreach (var row in _rows)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return row;
+      }
+    }
+  }
+
+  private sealed class StubNonStreamingReader<TRow> : IFormatRowReader<TRow>
+    where TRow : notnull
+  {
+    public StorageTraits Traits => new() { CanStream = false };
+
+    public async IAsyncEnumerable<TRow> DeserializeRows(
+      Stream stream,
+      [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      await Task.CompletedTask.ConfigureAwait(false);
+      yield break;
+    }
+  }
+}

--- a/tests/core/Flowthru.Core.Tests/Catalog/AsStreamTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Catalog/AsStreamTests.cs
@@ -112,6 +112,39 @@ public class AsStreamTests
     Assert.DoesNotThrow(() => item.AsStream());
   }
 
+  // ── StreamingItem node-delegation ──────────────────────────────────────
+
+  [Test]
+  public async Task StreamingItem_Exists_DelegatesToOrigin()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1 }).AsStream();
+    var result = await item.Exists().Run();
+    Assert.That(((EffResult<bool>.Success)result).Value, Is.True);
+  }
+
+  [Test]
+  public async Task StreamingItem_LoadUntyped_BoxesTheSource()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1, 2 }).AsStream();
+    var result = await item.LoadUntyped().Run();
+    Assert.That(((EffResult<object>.Success)result).Value, Is.InstanceOf<FlowSource<int>>());
+  }
+
+  [Test]
+  public void StreamingItem_DataType_IsFlowSource()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1 }).AsStream();
+    Assert.That(((IItem)item).DataType, Is.EqualTo(typeof(FlowSource<int>)));
+  }
+
+  [Test]
+  public async Task StreamingItem_SaveUntyped_Fails()
+  {
+    var item = StreamingSource(new StubMedium(), new[] { 1 }).AsStream();
+    var result = await item.SaveUntyped(FlowSource.Empty<int>()).Run();
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+  }
+
   // ── helpers ────────────────────────────────────────────────────────────
 
   private static IItem<IEnumerable<int>> StreamingSource(

--- a/tests/core/Flowthru.Core.Tests/Catalog/ItemIntrospectionTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Catalog/ItemIntrospectionTests.cs
@@ -1,4 +1,5 @@
 using Flowthru.Data.Catalog;
+using Flowthru.Prelude;
 using Flowthru.Step;
 
 namespace Flowthru.Core.Tests.Catalog;
@@ -59,10 +60,24 @@ public class ItemIntrospectionTests
   }
 
   [Test]
-  public void ContainerKindOf_IAsyncEnumerable_IsAsyncStream() =>
+  public void ContainerKindOf_FlowSource_IsSource() =>
+    // FlowSource<T> is the streaming catalog payload (.AsStream()). It
+    // implements none of the sequence interfaces, so introspection must
+    // recognise it structurally — otherwise it falls through to Singleton
+    // with row type FlowSource<T>, the bug ADR-0023 corrects.
+    Assert.That(
+      Item.ContainerKindOf<FlowSource<Row>>(),
+      Is.EqualTo(StepContainerKind.Source)
+    );
+
+  [Test]
+  public void ContainerKindOf_IAsyncEnumerable_IsSingleton() =>
+    // The bare-IAsyncEnumerable AsyncStream kind was removed (ADR-0023);
+    // a raw IAsyncEnumerable is no longer a recognised container kind and
+    // now resolves to Singleton. FlowSource is the sole streaming kind.
     Assert.That(
       Item.ContainerKindOf<IAsyncEnumerable<Row>>(),
-      Is.EqualTo(StepContainerKind.AsyncStream)
+      Is.EqualTo(StepContainerKind.Singleton)
     );
 
   // ── RowTypeOf ────────────────────────────────────────────────────────
@@ -88,8 +103,17 @@ public class ItemIntrospectionTests
     Assert.That(Item.RowTypeOf<IQueryable<Row>>(), Is.EqualTo(typeof(Row)));
 
   [Test]
-  public void RowTypeOf_AsyncStream_UnwrapsToRow() =>
-    Assert.That(Item.RowTypeOf<IAsyncEnumerable<Row>>(), Is.EqualTo(typeof(Row)));
+  public void RowTypeOf_FlowSource_UnwrapsToRow() =>
+    Assert.That(Item.RowTypeOf<FlowSource<Row>>(), Is.EqualTo(typeof(Row)));
+
+  [Test]
+  public void RowTypeOf_IAsyncEnumerable_ReturnsSelf() =>
+    // No longer a recognised container kind — treated as a Singleton, so
+    // its row type is the IAsyncEnumerable<Row> itself.
+    Assert.That(
+      Item.RowTypeOf<IAsyncEnumerable<Row>>(),
+      Is.EqualTo(typeof(IAsyncEnumerable<Row>))
+    );
 
   [Test]
   public void RowTypeOf_Array_ReturnsArrayType()

--- a/tests/core/Flowthru.Core.Tests/Flow/AddBulkLoadTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Flow/AddBulkLoadTests.cs
@@ -1,0 +1,103 @@
+using Flowthru.Core.Tests.Storage;
+using Flowthru.Data.Catalog;
+using Flowthru.Flow;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Core.Tests.Flow;
+
+/// <summary>
+/// Tests for the streaming bulk-load capstone (#123): the FlowSinkItem output
+/// and the on-DAG AddBulkLoad helper that wires a streaming source to a sink.
+/// </summary>
+[TestFixture]
+public class AddBulkLoadTests
+{
+  private string _tempDir = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _tempDir = Path.Combine(Path.GetTempPath(), $"flowthru-bulkload-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(_tempDir);
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    if (Directory.Exists(_tempDir))
+    {
+      try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+  }
+
+  [Test]
+  public async Task FlowSinkItem_Save_CompilesSourceIntoSink()
+  {
+    var sink = new RecordingSink<int>(batchSize: 2);
+    var item = new FlowSinkItem<int>("sink", sink);
+
+    var result = await item.Save(FlowSource.FromEnumerable(new[] { 1, 2, 3, 4, 5 })).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(sink.Rows, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+    Assert.That(sink.Completed, Is.True);
+  }
+
+  [Test]
+  public async Task FlowSinkItem_Load_Fails()
+  {
+    var item = new FlowSinkItem<int>("sink", new RecordingSink<int>(batchSize: 2));
+    var result = await item.Load().Run();
+    Assert.That(result, Is.InstanceOf<EffResult<FlowSource<int>>.Failure>());
+  }
+
+  [Test]
+  public async Task AddBulkLoad_RunsOnDag_WritesAllRows()
+  {
+    // Eager-save a JSON array, then stream it into a sink via an on-DAG step.
+    var path = Path.Combine(_tempDir, "orders.json");
+    var item = ItemFactory.Enumerable.Json<TestRow>("orders", path);
+    var rows = new[]
+    {
+      new TestRow { Id = 1, Name = "alpha" },
+      new TestRow { Id = 2, Name = "beta" },
+      new TestRow { Id = 3, Name = "gamma" },
+    };
+    await item.Save(rows).Run();
+
+    var sink = new RecordingSink<TestRow>(batchSize: 2);
+    var flow = FlowBuilder.CreateFlow("BulkLoadTest", p => p.AddBulkLoad(item.AsStream(), sink));
+
+    var result = await flow.RunAsync();
+
+    Assert.That(result.IsSuccess, Is.True, "The bulk-load flow should complete successfully.");
+    Assert.That(sink.Rows.Select(r => r.Id), Is.EqualTo(new[] { 1, 2, 3 }));
+    Assert.That(sink.Completed, Is.True);
+  }
+
+  private sealed class RecordingSink<T> : IFlowSink<T>
+  {
+    public RecordingSink(int batchSize) => BatchSize = batchSize;
+
+    public List<T> Rows { get; } = new();
+    public bool Completed { get; private set; }
+    public int BatchSize { get; }
+
+    public ValueTask OpenAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
+
+    public ValueTask WriteBatchAsync(IReadOnlyList<T> batch, CancellationToken cancellationToken)
+    {
+      Rows.AddRange(batch);
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CompleteAsync(CancellationToken cancellationToken)
+    {
+      Completed = true;
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+  }
+}

--- a/tests/core/Flowthru.Core.Tests/Prelude/FlowSourceTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Prelude/FlowSourceTests.cs
@@ -1,0 +1,264 @@
+using System.Runtime.CompilerServices;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.Core.Tests.Prelude;
+
+/// <summary>
+/// Tests for the <see cref="FlowSource{A}"/> streaming primitive — the
+/// compile-to-<see cref="FlowIO{A}"/> contract, deferred acquisition,
+/// bracketed resource safety, and the terminal/per-item error channels.
+/// </summary>
+[TestFixture]
+public class FlowSourceTests
+{
+  // ── Compile terminals + lazy combinators ───────────────────────────────
+
+  [Test]
+  public async Task ToList_YieldsAllElements()
+  {
+    var result = await FlowSource.FromEnumerable(new[] { 1, 2, 3 }).Compile().ToList().Run();
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Success>());
+    Assert.That(Value(result), Is.EqualTo(new[] { 1, 2, 3 }));
+  }
+
+  [Test]
+  public async Task MapAndWhere_TransformLazily()
+  {
+    var result = await FlowSource.FromEnumerable(new[] { 1, 2, 3, 4 })
+      .Where(x => x % 2 == 0)
+      .Map(x => x * 10)
+      .Compile()
+      .ToList()
+      .Run();
+
+    Assert.That(Value(result), Is.EqualTo(new[] { 20, 40 }));
+  }
+
+  [Test]
+  public async Task Fold_AccumulatesAcrossTheStream()
+  {
+    var result = await FlowSource.FromEnumerable(new[] { 1, 2, 3, 4 })
+      .Compile()
+      .Fold(0, (acc, x) => acc + x)
+      .Run();
+
+    Assert.That(((EffResult<int>.Success)result).Value, Is.EqualTo(10));
+  }
+
+  [Test]
+  public async Task Drain_RunsWithoutMaterialising()
+  {
+    var seen = new List<int>();
+    var result = await FlowSource.FromEnumerable(new[] { 1, 2, 3 })
+      .Map(x => { seen.Add(x); return x; })
+      .Compile()
+      .Drain()
+      .Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(seen, Is.EqualTo(new[] { 1, 2, 3 }));
+  }
+
+  // ── Deferred acquisition ───────────────────────────────────────────────
+
+  [Test]
+  public async Task Acquisition_IsDeferredUntilRun()
+  {
+    var acquired = false;
+    var source = FlowSource.Bracket(
+      TrackingResource(onAcquire: () => acquired = true, onRelease: _ => { }),
+      (scope, ct) => Range(1, 3, ct)
+    );
+
+    var effect = source.Compile().ToList(); // built AND compiled — but not run
+    Assert.That(acquired, Is.False, "Acquire must not run until the compiled effect is run.");
+
+    await effect.Run();
+    Assert.That(acquired, Is.True);
+  }
+
+  [Test]
+  public void BuiltButNeverCompiled_AcquiresNothing()
+  {
+    var acquired = false;
+    _ = FlowSource.Bracket(
+      TrackingResource(onAcquire: () => acquired = true, onRelease: _ => { }),
+      (scope, ct) => Range(1, 3, ct)
+    ).Map(x => x + 1); // combinators are pure description
+
+    Assert.That(acquired, Is.False);
+  }
+
+  // ── Bracketed resource safety ──────────────────────────────────────────
+
+  [Test]
+  public async Task Release_RunsOnCompletion_WithNoError()
+  {
+    var sequence = new List<string>();
+    var source = FlowSource.Bracket(
+      Sequenced(sequence),
+      (scope, ct) => Range(1, 2, ct)
+    );
+
+    await source.Compile().Drain().Run();
+    Assert.That(sequence, Is.EqualTo(new[] { "acquire", "release(ok)" }));
+  }
+
+  [Test]
+  public async Task Release_RunsOnMidStreamFailure_WithBodyError()
+  {
+    var sequence = new List<string>();
+    var source = FlowSource.Bracket(
+      Sequenced(sequence),
+      (scope, ct) => ThrowAfter(1, ct)
+    );
+
+    var result = await source.Compile().Drain().Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+    Assert.That(((EffResult<FlowUnit>.Failure)result).Error, Is.InstanceOf<RuntimeError.External>());
+    Assert.That(sequence, Is.EqualTo(new[] { "acquire", "release(External)" }));
+  }
+
+  [Test]
+  public async Task Release_RunsOnCancellation()
+  {
+    var sequence = new List<string>();
+    using var cts = new CancellationTokenSource();
+    var source = FlowSource.Bracket(
+      Sequenced(sequence),
+      (scope, ct) => CancelAfter(1, cts, ct)
+    );
+
+    var result = await source.Compile().Drain().Run(cts.Token);
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+    Assert.That(((EffResult<FlowUnit>.Failure)result).Error, Is.InstanceOf<RuntimeError.Cancelled>());
+    Assert.That(sequence, Is.EqualTo(new[] { "acquire", "release(Cancelled)" }));
+  }
+
+  // ── Error channel ──────────────────────────────────────────────────────
+
+  [Test]
+  public async Task TerminalFailure_IsTheDefault()
+  {
+    var result = await FlowSource.Lift<int>(ThrowAfter1).Compile().ToList().Run();
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
+    Assert.That(((EffResult<IReadOnlyList<int>>.Failure)result).Error, Is.InstanceOf<RuntimeError.External>());
+  }
+
+  [Test]
+  public async Task MapError_TranslatesTheTerminalFailure()
+  {
+    var mapped = new RuntimeError.SchemaMismatch("test", "translated");
+    var result = await FlowSource.Lift<int>(ThrowAfter1)
+      .MapError(_ => mapped)
+      .Compile()
+      .ToList()
+      .Run();
+
+    Assert.That(((EffResult<IReadOnlyList<int>>.Failure)result).Error, Is.SameAs(mapped));
+  }
+
+  [Test]
+  public async Task Attempt_MovesFailureInBandAsTrailingElement()
+  {
+    var result = await FlowSource.Lift<int>(ThrowAfter1).Attempt().Compile().ToList().Run();
+    var rows = Value(result);
+
+    Assert.That(rows, Has.Count.EqualTo(2));
+    Assert.That(rows[0], Is.InstanceOf<EffResult<int>.Success>());
+    Assert.That(((EffResult<int>.Success)rows[0]).Value, Is.EqualTo(1));
+    Assert.That(rows[1], Is.InstanceOf<EffResult<int>.Failure>());
+  }
+
+  [Test]
+  public async Task SkipErrors_KeepsSuccesses_AndReportsFailures()
+  {
+    var reported = new List<RuntimeError>();
+    var result = await FlowSource.Lift<int>(ThrowAfter1)
+      .Attempt()
+      .SkipErrors(reported.Add)
+      .Compile()
+      .ToList()
+      .Run();
+
+    Assert.That(Value(result), Is.EqualTo(new[] { 1 }));
+    Assert.That(reported, Has.Count.EqualTo(1));
+  }
+
+  [Test]
+  public async Task Rethrow_ReRaisesTheInBandFailureTerminally()
+  {
+    var result = await FlowSource.Lift<int>(ThrowAfter1)
+      .Attempt()
+      .Rethrow()
+      .Compile()
+      .ToList()
+      .Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private static IReadOnlyList<T> Value<T>(EffResult<IReadOnlyList<T>> result) =>
+    ((EffResult<IReadOnlyList<T>>.Success)result).Value;
+
+  private static FlowResource<int> TrackingResource(Action onAcquire, Action<RuntimeError?> onRelease) =>
+    FlowResource.Make(
+      acquire: FlowIO.Lift(() => { onAcquire(); return 0; }),
+      release: (_, error) => FlowIO.Lift(() => { onRelease(error); return FlowUnit.Default; })
+    );
+
+  private static FlowResource<int> Sequenced(List<string> sequence) =>
+    FlowResource.Make(
+      acquire: FlowIO.Lift(() => { sequence.Add("acquire"); return 0; }),
+      release: (_, error) => FlowIO.Lift(() =>
+      {
+        sequence.Add(error is null ? "release(ok)" : $"release({error.GetType().Name})");
+        return FlowUnit.Default;
+      })
+    );
+
+  private static async IAsyncEnumerable<int> Range(int start, int count, [EnumeratorCancellation] CancellationToken ct)
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    for (var i = 0; i < count; i++)
+    {
+      ct.ThrowIfCancellationRequested();
+      yield return start + i;
+    }
+  }
+
+  private static async IAsyncEnumerable<int> ThrowAfter(int emit, [EnumeratorCancellation] CancellationToken ct)
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    for (var i = 0; i < emit; i++)
+    {
+      ct.ThrowIfCancellationRequested();
+      yield return i + 1;
+    }
+
+    throw new InvalidOperationException("boom");
+  }
+
+  private static IAsyncEnumerable<int> ThrowAfter1(CancellationToken ct) => ThrowAfter(1, ct);
+
+  private static async IAsyncEnumerable<int> CancelAfter(
+    int emit,
+    CancellationTokenSource cts,
+    [EnumeratorCancellation] CancellationToken ct
+  )
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    for (var i = 0; i < emit; i++)
+    {
+      yield return i + 1;
+    }
+
+    cts.Cancel();
+    ct.ThrowIfCancellationRequested();
+  }
+}

--- a/tests/core/Flowthru.Core.Tests/Prelude/FlowSourceTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Prelude/FlowSourceTests.cs
@@ -201,6 +201,51 @@ public class FlowSourceTests
     Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
   }
 
+  // ── Into (sink) ────────────────────────────────────────────────────────
+
+  [Test]
+  public async Task Into_WritesBatches_ThenCompletes_ThenDisposes()
+  {
+    var events = new List<string>();
+    var sink = new FakeSink<int>(events, batchSize: 2);
+
+    var result = await FlowSource.FromEnumerable(new[] { 1, 2, 3, 4, 5 }).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(events, Is.EqualTo(new[] { "open", "write(2)", "write(2)", "write(1)", "complete", "dispose" }));
+    Assert.That(sink.Written, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+  }
+
+  [Test]
+  public async Task Into_OnMidStreamFailure_DisposesWithoutCompleting()
+  {
+    var events = new List<string>();
+    var sink = new FakeSink<int>(events, batchSize: 2);
+
+    var result = await FlowSource.Lift<int>(ThrowAfter1).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+    Assert.That(events, Does.Not.Contain("complete"));
+    Assert.That(events, Does.Contain("dispose"));
+  }
+
+  [Test]
+  public async Task Into_NestsSinkLifecycleInsideResourceBracket()
+  {
+    var events = new List<string>();
+    var resource = FlowResource.Make(
+      acquire: FlowIO.Lift(() => { events.Add("acquire"); return 0; }),
+      release: (_, _) => FlowIO.Lift(() => { events.Add("release"); return FlowUnit.Default; })
+    );
+    var sink = new FakeSink<int>(events, batchSize: 10);
+    var source = FlowSource.Bracket(resource, (scope, ct) => Range(1, 3, ct));
+
+    await source.Compile().Into(sink).Run();
+
+    Assert.That(events, Is.EqualTo(new[] { "acquire", "open", "write(3)", "complete", "dispose", "release" }));
+    Assert.That(sink.Written, Is.EqualTo(new[] { 1, 2, 3 }));
+  }
+
   // ── helpers ────────────────────────────────────────────────────────────
 
   private static IReadOnlyList<T> Value<T>(EffResult<IReadOnlyList<T>> result) =>
@@ -260,5 +305,44 @@ public class FlowSourceTests
 
     cts.Cancel();
     ct.ThrowIfCancellationRequested();
+  }
+
+  private sealed class FakeSink<T> : IFlowSink<T>
+  {
+    private readonly List<string> _events;
+
+    public FakeSink(List<string> events, int batchSize)
+    {
+      _events = events;
+      BatchSize = batchSize;
+    }
+
+    public List<T> Written { get; } = new();
+    public int BatchSize { get; }
+
+    public ValueTask OpenAsync(CancellationToken cancellationToken)
+    {
+      _events.Add("open");
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask WriteBatchAsync(IReadOnlyList<T> batch, CancellationToken cancellationToken)
+    {
+      _events.Add($"write({batch.Count})");
+      Written.AddRange(batch);
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask CompleteAsync(CancellationToken cancellationToken)
+    {
+      _events.Add("complete");
+      return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+      _events.Add("dispose");
+      return ValueTask.CompletedTask;
+    }
   }
 }

--- a/tests/core/Flowthru.Core.Tests/Storage/ComposedStorageAdapterFailureTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Storage/ComposedStorageAdapterFailureTests.cs
@@ -211,7 +211,9 @@ public class ComposedStorageAdapterFailureTests
 
     public StorageTraits Traits => new();
 
-    public IAsyncEnumerable<StubRow> DeserializeRows(Stream stream)
+    public IAsyncEnumerable<StubRow> DeserializeRows(
+      Stream stream,
+      CancellationToken cancellationToken = default)
     {
       if (_throwOnDeserialize)
       {

--- a/tests/core/Flowthru.Core.Tests/Storage/ComposedStorageAdapterTargetInspectionTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Storage/ComposedStorageAdapterTargetInspectionTests.cs
@@ -89,7 +89,9 @@ public class ComposedStorageAdapterTargetInspectionTests
   {
     public StorageTraits Traits => new();
 
-    public IAsyncEnumerable<StubRow> DeserializeRows(Stream stream) =>
+    public IAsyncEnumerable<StubRow> DeserializeRows(
+      Stream stream,
+      CancellationToken cancellationToken = default) =>
       AsyncEnumerable.Empty<StubRow>();
 
     public Task SerializeRows(Stream stream, IAsyncEnumerable<StubRow> rows) =>

--- a/tests/core/Flowthru.Core.Tests/Storage/JsonStreamingTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Storage/JsonStreamingTests.cs
@@ -1,0 +1,66 @@
+using Flowthru.Data.Catalog;
+using Flowthru.Data.Storage;
+using Flowthru.Prelude;
+
+namespace Flowthru.Core.Tests.Storage;
+
+/// <summary>
+/// End-to-end streaming for the core JSON format (#120): a JSON item's
+/// <c>.AsStream()</c> yields a working <c>FlowSource</c> that reads the array
+/// incrementally. The trait/marker honesty (CanStream ⇔ IFormatStreamReader)
+/// is enforced separately by <see cref="JsonFormatSerializerLaws_TestRow"/>.
+/// </summary>
+[TestFixture]
+public class JsonStreamingTests
+{
+  private string _tempDir = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _tempDir = Path.Combine(Path.GetTempPath(), $"flowthru-json-stream-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(_tempDir);
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    if (Directory.Exists(_tempDir))
+    {
+      try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort */ }
+    }
+  }
+
+  [Test]
+  public void Json_Serializer_HonestlyDeclaresStreaming()
+  {
+    var serializer = new JsonFormatSerializer<TestRow>();
+    Assert.That(serializer, Is.InstanceOf<IFormatStreamReader<TestRow>>());
+    Assert.That(serializer.Traits.CanStream, Is.True);
+  }
+
+  [Test]
+  public async Task Json_AsStream_ReadsTheArrayIncrementally()
+  {
+    var path = Path.Combine(_tempDir, "rows.json");
+    var item = ItemFactory.Enumerable.Json<TestRow>("rows", path);
+
+    var input = new[]
+    {
+      new TestRow { Id = 1, Name = "alpha" },
+      new TestRow { Id = 2, Name = "beta" },
+      new TestRow { Id = 3, Name = "gamma" },
+    };
+    var saved = await item.Save(input).Run();
+    Assert.That(saved, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+
+    // Stream it back through the read-only .AsStream() view.
+    var loadResult = await item.AsStream().Load().Run();
+    var source = ((EffResult<FlowSource<TestRow>>.Success)loadResult).Value;
+    var listResult = await source.Compile().ToList().Run();
+    var loaded = ((EffResult<IReadOnlyList<TestRow>>.Success)listResult).Value;
+
+    Assert.That(loaded.Select(r => r.Id), Is.EqualTo(new[] { 1, 2, 3 }));
+    Assert.That(loaded.Select(r => r.Name), Is.EqualTo(new[] { "alpha", "beta", "gamma" }));
+  }
+}

--- a/tests/core/Flowthru.Core.Tests/Storage/SchemaMismatchTranslationTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Storage/SchemaMismatchTranslationTests.cs
@@ -33,7 +33,9 @@ public class SchemaMismatchTranslationTests
   {
     public StorageTraits Traits => new();
 
-    public async IAsyncEnumerable<SmTestRow> DeserializeRows(SysIO.Stream stream)
+    public async IAsyncEnumerable<SmTestRow> DeserializeRows(
+      SysIO.Stream stream,
+      CancellationToken cancellationToken = default)
     {
       await Task.Yield();
       throw new SchemaMismatchException(
@@ -54,8 +56,10 @@ public class SchemaMismatchTranslationTests
   {
     private readonly ThrowingReader _reader = new();
     public StorageTraits Traits => _reader.Traits;
-    public IAsyncEnumerable<SmTestRow> DeserializeRows(SysIO.Stream stream) =>
-      _reader.DeserializeRows(stream);
+    public IAsyncEnumerable<SmTestRow> DeserializeRows(
+      SysIO.Stream stream,
+      CancellationToken cancellationToken = default) =>
+      _reader.DeserializeRows(stream, cancellationToken);
     public Task SerializeRows(SysIO.Stream stream, IAsyncEnumerable<SmTestRow> rows) =>
       Task.CompletedTask;
   }

--- a/tests/core/Flowthru.Core.Tests/Storage/SeekableSpillTests.cs
+++ b/tests/core/Flowthru.Core.Tests/Storage/SeekableSpillTests.cs
@@ -1,0 +1,75 @@
+using Flowthru.Data.Storage;
+
+namespace Flowthru.Core.Tests.Storage;
+
+/// <summary>
+/// Tests for <see cref="SeekableSpill"/> (#121): already-seekable sources pass
+/// through un-owned; forward-only sources spill to a seekable temp file whose
+/// content is preserved and which is deleted on dispose.
+/// </summary>
+[TestFixture]
+public class SeekableSpillTests
+{
+  [Test]
+  public async Task SeekableSource_PassesThrough_AndIsLeftOpen()
+  {
+    var source = new MemoryStream(new byte[] { 1, 2, 3 }) { Position = 2 };
+
+    await using (var spill = await SeekableSpill.CreateAsync(source))
+    {
+      Assert.That(spill.Stream, Is.SameAs(source), "An already-seekable source is returned as-is.");
+      Assert.That(spill.Stream.Position, Is.EqualTo(0), "It is rewound to the start.");
+    }
+
+    Assert.That(source.CanRead, Is.True, "The caller-owned stream is not disposed.");
+  }
+
+  [Test]
+  public async Task ForwardOnlySource_SpillsToSeekable_ContentPreserved_ThenDeleted()
+  {
+    var content = new byte[] { 10, 20, 30, 40, 50 };
+    var forwardOnly = new ForwardOnlyStream(new MemoryStream(content));
+
+    Stream spilled;
+    await using (var spill = await SeekableSpill.CreateAsync(forwardOnly))
+    {
+      spilled = spill.Stream;
+      Assert.That(spill.Stream.CanSeek, Is.True);
+
+      var first = new byte[content.Length];
+      await spill.Stream.ReadExactlyAsync(first);
+      Assert.That(first, Is.EqualTo(content));
+
+      // Genuinely seekable — rewind and re-read.
+      spill.Stream.Position = 0;
+      var second = new byte[content.Length];
+      await spill.Stream.ReadExactlyAsync(second);
+      Assert.That(second, Is.EqualTo(content));
+    }
+
+    Assert.That(spilled.CanRead, Is.False, "The spilled temp stream is disposed (and DeleteOnClose removes the file).");
+  }
+
+  private sealed class ForwardOnlyStream : Stream
+  {
+    private readonly Stream _inner;
+
+    public ForwardOnlyStream(Stream inner) => _inner = inner;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+      get => throw new NotSupportedException();
+      set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+  }
+}

--- a/tests/core/Flowthru.FUnit.Tests/FUnitStreamingTests.cs
+++ b/tests/core/Flowthru.FUnit.Tests/FUnitStreamingTests.cs
@@ -1,0 +1,224 @@
+using Flowthru.FUnit.Tests.Fixtures;
+using Flowthru.Prelude;
+using Flowthru.Step.Testing;
+using Flowthru.Validation.Runtime;
+
+namespace Flowthru.FUnit.Tests;
+
+/// <summary>
+/// Exercises the FUnit streaming affordance (issue #118) against
+/// <see cref="FlowSource{A}"/>: lifting samples into a stream, the async
+/// compile/drain invoke that unwinds the <see cref="EffResult{A}"/>, assertions
+/// for BOTH error modes (terminal <see cref="RuntimeError"/> and per-item
+/// dead-letter), and the hooks that observe bracket release and mid-stream
+/// cancellation (<see cref="TrackingSource{T}"/>) and sink lifecycle
+/// (<see cref="RecordingSink{T}"/>).
+/// </summary>
+[TestFixture]
+[Category("FUnit")]
+#pragma warning disable FU002 // FUnitContext subclass not guarded by #if FUNIT_ENABLED — this IS the test suite.
+public class FUnitStreamingTests : FUnitContext
+{
+  // ===========================================================================
+  // Lifting samples into a stream
+  // ===========================================================================
+
+  [Test]
+  public async Task Samples_Source_LiftsIntoFlowSource()
+  {
+    var input = Samples.Source(new NumberRow(1.0), new NumberRow(2.0));
+
+    var result = await InvokeStream(input);
+
+    Assert.That(result.Select(r => r.Value), Is.EqualTo(new[] { 1.0, 2.0 }));
+  }
+
+  [Test]
+  public async Task Samples_Of_AsStream_LiftsIntoFlowSource()
+  {
+    var input = Samples.Of(new NumberRow(3.0)).AsStream();
+
+    var result = await InvokeStream(input);
+
+    Assert.That(result, Has.Count.EqualTo(1));
+    Assert.That(result[0].Value, Is.EqualTo(3.0));
+  }
+
+  // ===========================================================================
+  // InvokeStream over a streaming step transform (Func<FlowSource, FlowSource>)
+  // ===========================================================================
+
+  [Test]
+  public async Task InvokeStream_Step_TransformsLazily()
+  {
+    Func<FlowSource<NumberRow>, FlowSource<NumberRow>> doubler =
+      src => src.Where(r => r.Value > 0).Map(r => r with { Value = r.Value * 2 });
+
+    var result = await InvokeStream(
+      doubler,
+      Samples.Of(new NumberRow(-1.0), new NumberRow(2.0), new NumberRow(3.0))
+    );
+
+    Assert.That(result.Select(r => r.Value), Is.EqualTo(new[] { 4.0, 6.0 }));
+  }
+
+  [Test]
+  public async Task InvokeStream_EmptyInput_ReturnsEmpty()
+  {
+    var result = await InvokeStream(Samples.Source<NumberRow>());
+
+    Assert.That(result, Is.Empty);
+  }
+
+  // ===========================================================================
+  // Error mode 1 — terminal RuntimeError (a failed compile)
+  // ===========================================================================
+
+  [Test]
+  public async Task RunStream_TerminalFailure_SurfacesAsEffResultFailure()
+  {
+    var source = FlowSource.Lift<int>(Boom);
+
+    var result = await RunStream(source);
+
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
+    var error = ((EffResult<IReadOnlyList<int>>.Failure)result).Error;
+    Assert.That(error, Is.InstanceOf<RuntimeError.External>());
+  }
+
+  [Test]
+  public void InvokeStream_TerminalFailure_Throws()
+  {
+    var source = FlowSource.Lift<int>(Boom);
+
+    Assert.CatchAsync<InvalidOperationException>(() => InvokeStream(source));
+  }
+
+  [Test]
+  public async Task RunStream_Success_YieldsRows()
+  {
+    var result = await RunStream(Samples.Source(1, 2, 3));
+
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Success>());
+    Assert.That(((EffResult<IReadOnlyList<int>>.Success)result).Value, Is.EqualTo(new[] { 1, 2, 3 }));
+  }
+
+  // ===========================================================================
+  // Error mode 2 — per-item dead-letter (FlowSource<EffResult<T>>)
+  // ===========================================================================
+
+  [Test]
+  public async Task InvokeStream_DeadLetter_MaterialisesPerItemOutcomes()
+  {
+    // A per-item stream: two good rows and one quarantined bad row.
+    var deadLettered = Samples.Source<EffResult<int>>(
+      new EffResult<int>.Success(1),
+      new EffResult<int>.Failure(new RuntimeError.External("bad-row", new Exception("corrupt"))),
+      new EffResult<int>.Success(3)
+    );
+
+    var outcomes = await InvokeStream(deadLettered);
+
+    Assert.That(outcomes, Has.Count.EqualTo(3));
+    Assert.That(outcomes[0], Is.InstanceOf<EffResult<int>.Success>());
+    Assert.That(outcomes[1], Is.InstanceOf<EffResult<int>.Failure>());
+    Assert.That(outcomes[2], Is.InstanceOf<EffResult<int>.Success>());
+  }
+
+  [Test]
+  public async Task InvokeStream_DeadLetter_SkipErrors_KeepsGoodRows()
+  {
+    var reported = new List<RuntimeError>();
+    var deadLettered = Samples.Source<EffResult<int>>(
+      new EffResult<int>.Success(1),
+      new EffResult<int>.Failure(new RuntimeError.External("bad-row", new Exception("corrupt"))),
+      new EffResult<int>.Success(3)
+    );
+
+    var kept = await InvokeStream(deadLettered.SkipErrors(reported.Add));
+
+    Assert.That(kept, Is.EqualTo(new[] { 1, 3 }));
+    Assert.That(reported, Has.Count.EqualTo(1));
+  }
+
+  // ===========================================================================
+  // Bracket release + mid-stream cancellation observability
+  // ===========================================================================
+
+  [Test]
+  public async Task TrackingSource_ReleasesBracket_OnCompletion()
+  {
+    var tracked = new TrackingSource<int>(new[] { 1, 2, 3 });
+
+    var rows = await InvokeStream(tracked.Source);
+
+    Assert.That(rows, Is.EqualTo(new[] { 1, 2, 3 }));
+    Assert.That(tracked.AcquireCount, Is.EqualTo(1));
+    Assert.That(tracked.Released, Is.True, "The pull-scoped bracket must release on completion.");
+    Assert.That(tracked.ReleaseCount, Is.EqualTo(1));
+    Assert.That(tracked.LastReleaseError, Is.Null, "Clean completion releases with a null error.");
+  }
+
+  [Test]
+  public async Task TrackingSource_ReleasesBracket_AndStopsRead_OnMidStreamCancellation()
+  {
+    using var cts = new CancellationTokenSource();
+    // Cancel after the second element is pulled — a mid-stream cancellation.
+    var tracked = new TrackingSource<int>(
+      new[] { 1, 2, 3, 4, 5 },
+      onPulled: index => { if (index == 2) cts.Cancel(); }
+    );
+
+    var result = await RunStream(tracked.Source, cts.Token);
+
+    Assert.That(result, Is.InstanceOf<EffResult<IReadOnlyList<int>>.Failure>());
+    Assert.That(((EffResult<IReadOnlyList<int>>.Failure)result).Error,
+      Is.InstanceOf<RuntimeError.Cancelled>());
+    Assert.That(tracked.Released, Is.True, "The bracket must release even when cancelled mid-stream.");
+    Assert.That(tracked.LastReleaseError, Is.InstanceOf<RuntimeError.Cancelled>());
+    Assert.That(tracked.PulledCount, Is.LessThan(5),
+      "A mid-stream cancel must stop the read before draining every element.");
+  }
+
+  // ===========================================================================
+  // Sink lifecycle observability (DrainInto + RecordingSink)
+  // ===========================================================================
+
+  [Test]
+  public async Task DrainInto_RecordingSink_CompletesAndDisposes()
+  {
+    var sink = new RecordingSink<int>(batchSize: 2);
+
+    var result = await DrainInto(Samples.Source(1, 2, 3, 4, 5), sink);
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(sink.Written, Is.EqualTo(new[] { 1, 2, 3, 4, 5 }));
+    Assert.That(sink.Events, Is.EqualTo(new[] { "open", "write(2)", "write(2)", "write(1)", "complete", "dispose" }));
+    Assert.That(sink.Completed, Is.True);
+    Assert.That(sink.Disposed, Is.True);
+  }
+
+  [Test]
+  public async Task DrainInto_OnMidStreamFailure_DisposesWithoutCompleting()
+  {
+    var sink = new RecordingSink<int>(batchSize: 2);
+
+    var result = await DrainInto(FlowSource.Lift<int>(Boom), sink);
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+    Assert.That(sink.Completed, Is.False, "A mid-stream failure must not complete the sink.");
+    Assert.That(sink.Disposed, Is.True, "Dispose (rollback) must still run on the failure path.");
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private static async IAsyncEnumerable<int> BoomImpl()
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    yield return 1;
+    throw new InvalidOperationException("boom");
+  }
+
+  private static IAsyncEnumerable<int> Boom(CancellationToken ct) => BoomImpl();
+}
+#pragma warning restore FU002

--- a/tests/extensions/CONTRIBUTING.md
+++ b/tests/extensions/CONTRIBUTING.md
@@ -90,6 +90,31 @@ podman run --rm --network=host --memory=1g --cpus=0.5 -v "$PWD":/work -w /work \
 
 [ParquetOverS3ConcurrencyTests](/tests/extensions/Flowthru.Extensions.AWS.S3.Tests/ParquetOverS3ConcurrencyTests.cs) is the reference case. Test non-local storage under production-like limits, not just functionally.
 
+### Streaming tier — RSS stays flat as row count grows (#124)
+
+The eager tier above proves the *cap holds* for whole-object reads (bounded fan-out). The streaming tier proves the ADR-0023 remedy: a `.AsStream()` read of a **multi-row-group** `s3://` Parquet object is O(one row group), so a *single* streaming read of an arbitrarily large object — and a whole layer of concurrent ones — survives a cap that whole-object buffering would blow. [StreamingParquetOverS3Tests](/tests/extensions/Flowthru.Extensions.AWS.S3.Tests/StreamingParquetOverS3Tests.cs) is the reference case: it asserts only correctness (every streamed read returns all seeded rows, in order, checksum-verified); the **flat-RSS invariant is the job's to enforce** — crank `FLOWTHRU_STREAM_ROWS` and the capped test process's RSS must not track it.
+
+This tier self-provisions MinIO via Testcontainers (gated on `TestCapabilities.Docker`), so — unlike the sidecar pattern above — MinIO is launched as a **sibling container on the host socket**, outside the cap; only the *test process* is memory-limited:
+
+```bash
+# Streaming O(row group) regression (#124): a multi-row-group s3:// Parquet object
+# streamed back through .AsStream(). RSS of the *capped test process* stays FLAT as
+# FLOWTHRU_STREAM_ROWS grows; the eager whole-object path would blow the 1 GB cap.
+# Testcontainers launches MinIO as a sibling on the mounted host socket — the MinIO
+# container is NOT counted against --memory; only the test process is. A `docker`
+# shim is needed for the capability probe (`which docker`) when the runtime is podman.
+podman run --rm --network=host --memory=1g --cpus=0.5 -v "$PWD":/work -w /work \
+  -v /run/user/1000/podman/podman.sock:/var/run/docker.sock \
+  -e DOCKER_HOST=unix:///var/run/docker.sock -e TESTCONTAINERS_RYUK_DISABLED=true \
+  -e FLOWTHRU_STREAM_ROWS=2000000 -e FLOWTHRU_STREAM_ROWGROUP=50000 \
+  mcr.microsoft.com/dotnet/sdk:10.0 sh -c \
+  'ln -sf "$(command -v podman || echo /usr/bin/docker)" /usr/local/bin/docker; dotnet vstest \
+   dist/tests/extensions/Flowthru.Extensions.AWS.S3.Tests/net10.0/Flowthru.Extensions.AWS.S3.Tests.dll \
+   --TestCaseFilter:"FullyQualifiedName~StreamingParquetOverS3Tests"'
+```
+
+Both tiers share the discipline: the test asserts the *right rows*; the container job imposes the *memory ceiling*. Neither test measures its own RSS.
+
 ## Glossary
 
 ### Roles

--- a/tests/extensions/Flowthru.Extensions.AWS.S3.Tests/StreamingParquetOverS3Tests.cs
+++ b/tests/extensions/Flowthru.Extensions.AWS.S3.Tests/StreamingParquetOverS3Tests.cs
@@ -1,0 +1,327 @@
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Flowthru.Data.Catalog;
+using Flowthru.Data.Storage;
+using Flowthru.Data.Storage.Parquet;
+using Flowthru.Data.Storage.S3;
+using Flowthru.Hosting;
+using Flowthru.Prelude;
+using Flowthru.Tests.Kits.Prelude;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Parquet;
+
+namespace Flowthru.Extensions.AWS.S3.Tests;
+
+/// <summary>
+/// Regression coverage for reading a <strong>multi-row-group</strong>
+/// <c>s3://</c> Parquet object back through the <em>streaming</em> catalog view —
+/// the ADR-0023 path that bounds peak read memory to O(one row group) instead of
+/// O(whole object). Drives the production wiring end-to-end:
+/// <c>ItemFactory.Enumerable.Parquet(...).AsStream()</c> →
+/// <c>Load()</c> (deferred <see cref="FlowSource{T}"/>) →
+/// <c>Compile().ToList()</c>/<c>Fold</c>, over a real MinIO S3 server whose
+/// forward-only response body forces the Parquet reader's
+/// <c>SeekableSpill</c> (temp-file spill, one row group resident at a time).
+/// A wide fan-out of concurrent streaming reads mirrors the parallel scheduler
+/// dispatching a whole layer of <c>s3://</c> inputs (issue #124).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Self-provisioning MinIO, gated on <see cref="TestCapabilities.Docker"/>.</strong>
+/// Unlike <see cref="ParquetOverS3ConcurrencyTests"/> (which targets any external
+/// S3 endpoint via <c>FLOWTHRU_S3_TEST_*</c>), this tier spins up a
+/// <c>Testcontainers</c>-managed MinIO container — mirroring
+/// <see cref="Backends.MinioContainerBackend"/> — so it needs no AWS account and
+/// no external endpoint. When Docker/podman is unavailable the fixture reports
+/// <em>Inconclusive</em> (never a failure), so a runtime-less host stays green.
+/// </para>
+/// <para>
+/// <strong>The memory ceiling is imposed externally.</strong> This test asserts
+/// only <em>correctness</em> — every streamed read returns all seeded rows, in
+/// order, uncorrupted. It does <em>not</em> measure its own RSS. The
+/// constrained-container CI job (<c>tests/extensions/CONTRIBUTING.md</c>,
+/// "Constrained-Resource Tiers") runs it under an explicit <c>--memory</c> cap;
+/// because each streaming read is O(row group), the process RSS must stay flat as
+/// <c>FLOWTHRU_STREAM_ROWS</c> grows — the eager path (whole-object buffering)
+/// would blow the cap. Load knobs (env, with defaults):
+/// <c>FLOWTHRU_STREAM_ROWS</c> (40000), <c>FLOWTHRU_STREAM_ROWGROUP</c> (4000, so
+/// ~10 groups), <c>FLOWTHRU_STREAM_OBJECTS</c> (8, the fan-out width),
+/// <c>FLOWTHRU_STREAM_MAXPAR</c> (= objects).
+/// </para>
+/// </remarks>
+[TestFixture]
+[Category("AwsS3")]
+[Category("Integration")]
+[Category("RequiresDocker")]
+public class StreamingParquetOverS3Tests
+{
+  private const string AccessKey = "minioadmin";
+  private const string SecretKey = "minioadmin";
+  private const string Bucket = "flowthru-streaming";
+
+  private IContainer? _container;
+  private string _endpoint = null!;
+  private int _rows;
+  private int _rowGroupSize;
+  private int _objects;
+
+  private static string Env(string key, string dflt) =>
+    Environment.GetEnvironmentVariable(key) is { Length: > 0 } v ? v : dflt;
+
+  [OneTimeSetUp]
+  public async Task StartMinioAndSeed()
+  {
+    // Capability gate: no Docker/podman ⇒ Inconclusive before the container ever
+    // starts. Mirrors MinioContainerBackend / the extension-test gating convention.
+    Assume.That(TestCapabilities.Docker.IsAvailable(),
+      $"[{TestCapabilities.Docker.Name}] {TestCapabilities.Docker.MissingMessage}");
+
+    _rows = int.Parse(Env("FLOWTHRU_STREAM_ROWS", "40000"));
+    _rowGroupSize = int.Parse(Env("FLOWTHRU_STREAM_ROWGROUP", "4000"));
+    _objects = int.Parse(Env("FLOWTHRU_STREAM_OBJECTS", "8"));
+
+    _container = new ContainerBuilder()
+      .WithImage("minio/minio:latest")
+      .WithEnvironment("MINIO_ROOT_USER", AccessKey)
+      .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
+      .WithCommand("server", "/data")
+      .WithPortBinding(9000, assignRandomHostPort: true)
+      .WithWaitStrategy(Wait.ForUnixContainer()
+        .UntilHttpRequestIsSucceeded(r => r.ForPath("/minio/health/ready").ForPort(9000)))
+      .Build();
+    await _container.StartAsync();
+    _endpoint = $"http://{_container.Hostname}:{_container.GetMappedPublicPort(9000)}";
+
+    using var admin = new AmazonS3Client(
+      new BasicAWSCredentials(AccessKey, SecretKey),
+      new AmazonS3Config
+      {
+        ServiceURL = _endpoint,
+        ForcePathStyle = true,
+        AuthenticationRegion = "us-east-1",
+      });
+    await admin.PutBucketAsync(Bucket);
+
+    // A small RowGroupSize relative to the row count forces several row groups,
+    // so a streaming read genuinely advances group-by-group (rather than a
+    // single-group file that a reader could satisfy in one pass).
+    var bytes = await BuildMultiRowGroupParquet(_rows, _rowGroupSize);
+
+    // Honesty check: prove the seed really is multi-row-group, so the test
+    // exercises the incremental-yield path it claims to.
+    using (var probe = new MemoryStream(bytes, writable: false))
+    using (var reader = await ParquetReader.CreateAsync(probe))
+    {
+      Assert.That(reader.RowGroupCount, Is.GreaterThan(1),
+        "Seed object must span multiple row groups to exercise streaming; "
+        + $"lower FLOWTHRU_STREAM_ROWGROUP below FLOWTHRU_STREAM_ROWS ({_rows}).");
+    }
+
+    foreach (var i in Enumerable.Range(0, _objects))
+    {
+      using var body = new MemoryStream(bytes, writable: false);
+      await admin.PutObjectAsync(new PutObjectRequest
+      {
+        BucketName = Bucket,
+        Key = ObjectKey(i),
+        InputStream = body,
+        AutoCloseStream = false,
+      });
+    }
+
+    TestContext.Out.WriteLine(
+      $"[s3-streaming] seeded {_objects} objects x {_rows} rows "
+      + $"(rowGroupSize={_rowGroupSize}), {bytes.Length:N0} bytes/object into "
+      + $"'{Bucket}' at {_endpoint}");
+  }
+
+  [OneTimeTearDown]
+  public async Task StopMinio()
+  {
+    if (_container is not null)
+    {
+      await _container.DisposeAsync();
+      _container = null;
+    }
+  }
+
+  /// <summary>
+  /// The core streaming assertion: one <c>.AsStream()</c> read of a multi-row-group
+  /// object returns every seeded row, in order, with correct field values.
+  /// </summary>
+  [Test]
+  public async Task StreamedRead_ReturnsAllSeededRows_InOrder()
+  {
+    using var sp = BuildProvider();
+    var item = ParquetItem(sp, ObjectKey(0));
+
+    // The path under test: the streaming view's Load() hands back a deferred
+    // source, which compiles back into a FlowIO we materialise. Peak read memory
+    // is one row group even though ToList collects the whole (single-object) result.
+    var source = Unwrap(await item.Load().Run());
+    var rows = Unwrap(await source.Compile().ToList().Run());
+
+    Assert.That(rows, Has.Count.EqualTo(_rows), "Streamed read dropped or duplicated rows.");
+
+    // Spot-check values at the ends and interior — order and content both.
+    Assert.That(rows[0].Id, Is.EqualTo(0));
+    Assert.That(rows[^1].Id, Is.EqualTo(_rows - 1));
+    var mid = _rows / 2;
+    Assert.That(rows[mid].Id, Is.EqualTo(mid));
+    Assert.That(rows[mid].Name, Is.EqualTo($"name-{mid}"));
+    Assert.That(rows[mid].Category, Is.EqualTo($"cat-{mid % 50}"));
+    Assert.That(rows[mid].V2, Is.EqualTo(mid * 2.2).Within(1e-9));
+  }
+
+  /// <summary>
+  /// A wide layer of concurrent streaming reads — the shape the parallel scheduler
+  /// dispatches — all return correct rows. Each read counts via <c>Fold</c>
+  /// (O(row group), not O(object)), so under a constrained-container cap RSS stays
+  /// flat regardless of fan-out width or row count.
+  /// </summary>
+  [Test]
+  public async Task ConcurrentStreamedReads_StayConsistent()
+  {
+    using var sp = BuildProvider();
+    var items = Enumerable.Range(0, _objects)
+      .Select(i => ParquetItem(sp, ObjectKey(i)))
+      .ToList();
+
+    var maxPar = int.Parse(Env("FLOWTHRU_STREAM_MAXPAR", _objects.ToString()));
+    using var gate = new SemaphoreSlim(maxPar, maxPar);
+
+    // The whole dataset's Id column sums to the triangular number — a checksum
+    // that catches missing, duplicated, or corrupted rows without materialising
+    // the stream (keeping each concurrent read O(row group)).
+    var expectedIdSum = (long)_rows * (_rows - 1) / 2;
+
+    async Task<(string Label, long Count, long IdSum, string? Error)> StreamCount(
+      IReadOnlyItem<FlowSource<PqRow>> item)
+    {
+      await gate.WaitAsync();
+      try
+      {
+        var loaded = await item.Load().Run();
+        if (loaded is EffResult<FlowSource<PqRow>>.Failure lf)
+        {
+          return (item.Label, -1, -1, lf.Error.Message);
+        }
+
+        var source = ((EffResult<FlowSource<PqRow>>.Success)loaded).Value;
+        var tally = await source.Compile()
+          .Fold(new ReadTally(0, 0), static (t, row) => new ReadTally(t.Count + 1, t.IdSum + row.Id))
+          .Run();
+
+        if (tally is EffResult<ReadTally>.Failure tf)
+        {
+          return (item.Label, -1, -1, tf.Error.Message);
+        }
+
+        var value = ((EffResult<ReadTally>.Success)tally).Value;
+        return (item.Label, value.Count, value.IdSum, null);
+      }
+      catch (Exception ex)
+      {
+        return (item.Label, -1, -1, $"{ex.GetType().Name}: {ex.Message}");
+      }
+      finally
+      {
+        gate.Release();
+      }
+    }
+
+    var results = await Task.WhenAll(items.Select(i => Task.Run(() => StreamCount(i))));
+
+    var failures = results.Where(r => r.Error is not null).ToList();
+    var wrongCount = results.Where(r => r.Error is null && r.Count != _rows).ToList();
+    var wrongSum = results.Where(r => r.Error is null && r.IdSum != expectedIdSum).ToList();
+    TestContext.Out.WriteLine(
+      $"[s3-streaming] maxPar={maxPar} "
+      + $"ok={results.Count(r => r.Error is null && r.Count == _rows && r.IdSum == expectedIdSum)}/{_objects} "
+      + $"failed={failures.Count} wrongCount={wrongCount.Count} wrongSum={wrongSum.Count}");
+    foreach (var f in failures.Take(5))
+    {
+      TestContext.Out.WriteLine($"[s3-streaming]   FAIL {f.Label}: {f.Error}");
+    }
+
+    Assert.That(failures, Is.Empty,
+      $"Concurrent streaming reads produced {failures.Count} decode/integrity failures (issue #124).");
+    Assert.That(wrongCount, Is.Empty, "Some streaming reads returned the wrong row count.");
+    Assert.That(wrongSum, Is.Empty, "Some streaming reads returned corrupted/reordered rows (Id checksum mismatch).");
+  }
+
+  // ── wiring ──────────────────────────────────────────────────────────────
+
+  private ServiceProvider BuildProvider()
+  {
+    var services = new ServiceCollection();
+    services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+    // Production wiring over the injected-gateway swap point: an AmazonS3Gateway
+    // pointed at the MinIO container with its basic credentials. No process-env
+    // mutation — mirrors MinioContainerBackend's client build.
+    var client = new AmazonS3Client(
+      new BasicAWSCredentials(AccessKey, SecretKey),
+      new AmazonS3Config
+      {
+        ServiceURL = _endpoint,
+        ForcePathStyle = true,
+        AuthenticationRegion = "us-east-1",
+      });
+    services.AddFlowthru(b => b.UseS3(new AmazonS3Gateway(client)));
+    return services.BuildServiceProvider();
+  }
+
+  private IReadOnlyItem<FlowSource<PqRow>> ParquetItem(ServiceProvider sp, string key)
+  {
+    var resolver = sp.GetRequiredService<IStorageMediumResolver>();
+    return ItemFactory.Enumerable
+      .Parquet<PqRow>(label: key, filePath: $"s3://{Bucket}/{key}", resolver: resolver)
+      .AsStream();
+  }
+
+  private static string ObjectKey(int i) => $"flowthru-streaming/obj{i}.parquet";
+
+  private static async Task<byte[]> BuildMultiRowGroupParquet(int rows, int rowGroupSize)
+  {
+    // Reuses the PqRow schema and ParquetFormatSerializer from
+    // ParquetOverS3ConcurrencyTests; the only difference is an explicit small
+    // RowGroupSize so the object spans multiple groups.
+    var serializer = new ParquetFormatSerializer<PqRow>(
+      new ParquetItemOptions<PqRow> { RowGroupSize = rowGroupSize });
+    using var ms = new MemoryStream();
+    await serializer.SerializeRows(ms, Generate(rows));
+    return ms.ToArray();
+  }
+
+  private static async IAsyncEnumerable<PqRow> Generate(int rows)
+  {
+    for (var i = 0; i < rows; i++)
+    {
+      yield return new PqRow
+      {
+        Id = i,
+        Name = $"name-{i}",
+        Category = $"cat-{i % 50}",
+        V1 = i * 1.1,
+        V2 = i * 2.2,
+        V3 = i * 3.3,
+        Flags = i % 7,
+        Payload = new string((char)('a' + (i % 26)), 64),
+      };
+      if ((i & 4095) == 0) await Task.Yield();
+    }
+  }
+
+  private static T Unwrap<T>(EffResult<T> result) =>
+    result is EffResult<T>.Success s
+      ? s.Value
+      : throw new AssertionException(
+          $"Expected a successful effect, got failure: {((EffResult<T>.Failure)result).Error}");
+
+  /// <summary>A streaming read's running total — row count plus an Id checksum.</summary>
+  private readonly record struct ReadTally(long Count, long IdSum);
+}

--- a/tests/extensions/Flowthru.Extensions.EFCore.Bulk.Tests/EFCoreBulkSinkTests.cs
+++ b/tests/extensions/Flowthru.Extensions.EFCore.Bulk.Tests/EFCoreBulkSinkTests.cs
@@ -1,0 +1,190 @@
+using System.Runtime.CompilerServices;
+using Flowthru.Prelude;
+using Flowthru.Validation.Runtime;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Flowthru.Extensions.EFCore.Bulk.Tests;
+
+/// <summary>
+/// Tests for <see cref="EFCoreBulkSink{T, TContext}"/> / <see cref="BulkSink"/> —
+/// the streaming per-batch, single-transaction bulk-insert sink. Exercises the
+/// end-to-end <c>FlowSource → Into(sink)</c> path (issue #122): all rows on
+/// success, incremental per-batch writes (O(batch)), and a full rollback when
+/// the stream fails mid-way.
+/// </summary>
+/// <remarks>
+/// Uses a shared, open SQLite in-memory connection so that the sink's context
+/// (which opens a transaction) and a separate verification context observe the
+/// same database — a fresh <c>DataSource=:memory:</c> per connection would give
+/// each context its own empty database.
+/// </remarks>
+[TestFixture]
+public class EFCoreBulkSinkTests
+{
+  private SqliteConnection _connection = null!;
+  private TestDbContextFactory _factory = null!;
+
+  [SetUp]
+  public void SetUp()
+  {
+    _connection = new SqliteConnection("DataSource=:memory:");
+    _connection.Open();
+
+    var options = new DbContextOptionsBuilder<TestDbContext>().UseSqlite(_connection).Options;
+
+    _factory = new TestDbContextFactory(options);
+
+    using var db = _factory.CreateDbContext();
+    db.Database.EnsureCreated();
+  }
+
+  [TearDown]
+  public void TearDown()
+  {
+    _connection.Dispose();
+  }
+
+  [Test]
+  public void Insert_Returns_Sink()
+  {
+    var sink = BulkSink.Insert<TestEntity, TestDbContext>(_factory);
+    Assert.That(sink, Is.Not.Null);
+    Assert.That(sink, Is.InstanceOf<IFlowSink<TestEntity>>());
+  }
+
+  [Test]
+  public void BatchSize_Comes_From_Options()
+  {
+    var sink = BulkSink.Insert<TestEntity, TestDbContext>(
+      _factory,
+      new BulkSaveOptions { BatchSize = 500 }
+    );
+    Assert.That(sink.BatchSize, Is.EqualTo(500));
+  }
+
+  [Test]
+  public void BatchSize_Defaults_To_2000()
+  {
+    var sink = BulkSink.Insert<TestEntity, TestDbContext>(_factory);
+    Assert.That(sink.BatchSize, Is.EqualTo(2000));
+  }
+
+  [Test]
+  public async Task Into_WritesAllRows_OnSuccess()
+  {
+    var entities = MakeEntities(1, 5).ToArray();
+    var sink = BulkSink.Insert<TestEntity, TestDbContext>(
+      _factory,
+      new BulkSaveOptions { BatchSize = 2 }
+    );
+
+    var result = await FlowSource.FromEnumerable(entities).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+
+    var rows = await ReadAllAsync();
+    Assert.That(rows, Has.Count.EqualTo(5));
+    Assert.That(rows.Select(e => e.Id), Is.EquivalentTo(new[] { 1, 2, 3, 4, 5 }));
+  }
+
+  [Test]
+  public async Task Into_WritesIncrementally_PerBatch()
+  {
+    // 5 rows at BatchSize 2 → three write calls: [2, 2, 1]. Proves the write is
+    // O(batch) per-batch, not a single materialised bulk insert.
+    var entities = MakeEntities(1, 5).ToArray();
+    var sink = (EFCoreBulkSink<TestEntity, TestDbContext>)
+      BulkSink.Insert<TestEntity, TestDbContext>(_factory, new BulkSaveOptions { BatchSize = 2 });
+
+    var result = await FlowSource.FromEnumerable(entities).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(sink.BatchesWritten, Is.EqualTo(3));
+  }
+
+  [Test]
+  public async Task Into_EmptyStream_CommitsNothing()
+  {
+    var sink = BulkSink.Insert<TestEntity, TestDbContext>(_factory);
+
+    var result = await FlowSource.FromEnumerable(Array.Empty<TestEntity>()).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Success>());
+    Assert.That(await CountAsync(), Is.EqualTo(0));
+  }
+
+  [Test]
+  public async Task Into_MidStreamFailure_RollsBackEntireWrite()
+  {
+    // Emit two batches' worth then throw: at least one batch is bulk-inserted
+    // into the open transaction before the failure. A truthful IsTransactional
+    // means the table is empty afterwards — no corrupt-but-present rows.
+    var sink = (EFCoreBulkSink<TestEntity, TestDbContext>)
+      BulkSink.Insert<TestEntity, TestDbContext>(_factory, new BulkSaveOptions { BatchSize = 2 });
+
+    var result = await FlowSource.Lift<TestEntity>(ct => FailAfter(3, ct)).Compile().Into(sink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+    Assert.That(
+      ((EffResult<FlowUnit>.Failure)result).Error,
+      Is.InstanceOf<RuntimeError.External>()
+    );
+
+    // A batch was actually bulk-inserted into the transaction before the throw,
+    // so the empty table below proves a genuine rollback (not a no-op).
+    Assert.That(sink.BatchesWritten, Is.EqualTo(1));
+    Assert.That(await CountAsync(), Is.EqualTo(0), "Partial-stream failure must roll the whole write back.");
+  }
+
+  [Test]
+  public async Task Into_MidStreamFailure_AfterPriorSuccessfulRun_LeavesOnlyCommittedRows()
+  {
+    // A committed run followed by a rolled-back run must leave exactly the
+    // committed rows — the rollback touches only its own transaction.
+    var committed = MakeEntities(1, 3).ToArray();
+    var okSink = BulkSink.Insert<TestEntity, TestDbContext>(_factory, new BulkSaveOptions { BatchSize = 2 });
+    await FlowSource.FromEnumerable(committed).Compile().Into(okSink).Run();
+
+    var failSink = BulkSink.Insert<TestEntity, TestDbContext>(_factory, new BulkSaveOptions { BatchSize = 2 });
+    var result = await FlowSource.Lift<TestEntity>(ct => FailAfter(4, ct, startId: 100)).Compile().Into(failSink).Run();
+
+    Assert.That(result, Is.InstanceOf<EffResult<FlowUnit>.Failure>());
+
+    var rows = await ReadAllAsync();
+    Assert.That(rows.Select(e => e.Id), Is.EquivalentTo(new[] { 1, 2, 3 }));
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private static IEnumerable<TestEntity> MakeEntities(int startId, int count) =>
+    Enumerable.Range(startId, count).Select(i => new TestEntity { Id = i, Name = $"row-{i}" });
+
+  private static async IAsyncEnumerable<TestEntity> FailAfter(
+    int emit,
+    [EnumeratorCancellation] CancellationToken ct,
+    int startId = 1
+  )
+  {
+    await Task.CompletedTask.ConfigureAwait(false);
+    for (var i = 0; i < emit; i++)
+    {
+      ct.ThrowIfCancellationRequested();
+      yield return new TestEntity { Id = startId + i, Name = $"row-{startId + i}" };
+    }
+
+    throw new InvalidOperationException("boom");
+  }
+
+  private async Task<int> CountAsync()
+  {
+    await using var db = _factory.CreateDbContext();
+    return await db.TestEntities.CountAsync();
+  }
+
+  private async Task<List<TestEntity>> ReadAllAsync()
+  {
+    await using var db = _factory.CreateDbContext();
+    return await db.TestEntities.AsNoTracking().ToListAsync();
+  }
+}

--- a/tests/extensions/Flowthru.Extensions.Python.Tests/PythonStepExtensionDescriptorTests.cs
+++ b/tests/extensions/Flowthru.Extensions.Python.Tests/PythonStepExtensionDescriptorTests.cs
@@ -51,16 +51,6 @@ public class PythonStepExtensionDescriptorTests
   }
 
   [Test]
-  public void PythonStepExtension_DoesNotImplementAsyncStreamMarshaller()
-  {
-    // The subprocess executor doesn't stream rows lazily; same
-    // reasoning as Queryable above.
-    Assert.That(
-      typeof(IAsyncStreamMarshaller<PythonStepExtension>).IsAssignableFrom(typeof(PythonStepExtension)),
-      Is.False);
-  }
-
-  [Test]
   public void PythonStepExtension_DeclaresProductionFloorCapabilities()
   {
     var attr = typeof(PythonStepExtension)
@@ -82,7 +72,8 @@ public class PythonStepExtensionDescriptorTests
     // Negative assertion — Phase 9's deliberate scope:
     Assert.That(attr.Inputs & StepContainerKind.Queryable, Is.EqualTo(StepContainerKind.None),
       "The Python extension does not currently support Queryable inputs.");
-    Assert.That(attr.Inputs & StepContainerKind.AsyncStream, Is.EqualTo(StepContainerKind.None),
-      "The Python extension does not currently support AsyncStream inputs.");
+    Assert.That(attr.Inputs & StepContainerKind.Source, Is.EqualTo(StepContainerKind.None),
+      "The Python extension does not currently declare Source (FlowSource) inputs — "
+      + "it consumes the eager Enumerable view and marshals via Arrow (ADR-0023).");
   }
 }


### PR DESCRIPTION
Implements the streaming-native reads milestone (**ADR-0023**): bound a catalog read's peak memory to **O(batch)** instead of O(file), so Flowthru can process datasets larger than RAM on memory-constrained hosts (AWS Lambda, lightweight ECS/Fargate) — the principled root fix behind the #111 Fargate OOM.

## What's in it

- **`FlowSource<T>`** — a lazy, resource-safe, error-as-value streaming primitive (the streaming sibling of `FlowIO`), vendored minimally and consumed only by compiling back into `FlowIO`. (#113)
- **cancellation** threaded through `DeserializeRows`. (#114)
- **`FlowSink<T>` + `.Compile().Into(sink)`** batch-sink terminal. (#115)
- **`.AsStream()`** — a read-only streaming catalog view with deferred, bracketed `Load()`. (#116)
- **`StepContainerKind.Source`** + introspection; the old `AsyncStream` / `IAsyncStreamMarshaller` scaffolding removed. (#117)
- **FUnit streaming affordance + FT1201 trait-honesty analyzer.** (#118)
- **streaming JSON** (core) and **streaming Parquet + a shared make-seekable spill** — O(row-group) RAM over a forward-only S3 body. (#120, #121)
- **`IFlowSink<T>` EFCore.Bulk streaming sink** (per-batch, one transaction). (#122)
- **`AddBulkLoad`** — the on-DAG, intent-level bulk-load helper. (#123)
- **constrained-memory MinIO regression tier** — ran green against real MinIO. (#124)
- **`StreamingBulkLoad` advanced example** — large Parquet → SQLite, self-measuring: **eager peak 166 MB vs streaming 25 MB (15% of eager)**, rendered by a Flowthru Reporting flow.

## Proof, not just claims
- `FlowSource.cs` at **100% line coverage**; the whole stack 84–100%.
- **End-to-end**: #123 runs a real flow through the scheduler (JSON `.AsStream()` → `AddBulkLoad` → sink, `IsSuccess`); #124 streams a multi-row-group Parquet over real MinIO (8/8 concurrent reads consistent, driving the `SeekableSpill`).
- Full solution builds green.

## Issues

Closes #112. Closes #113. Closes #114. Closes #115. Closes #116. Closes #117. Closes #118. Closes #120. Closes #121. Closes #122. Closes #123. Closes #124.

**#119 stays open by design** (do not auto-close). Python's chunk-wise Arrow marshalling is deferred: a v1 step consumes the eager view (forced-upstream `FlowSource` inputs are forbidden), and true incremental marshalling needs an Arrow-IPC wire-protocol change on both the C# and Python sides. The marker migration landed here (build green); the O(batch) guarantee holds for the C# path but not across a Python step. Tracked as a scoped follow-up in #119.